### PR TITLE
Modified algorithm to generate object name suffix on ObjectFactoryGenerator.java

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/impl/generator/ObjectFactoryGenerator.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/ObjectFactoryGenerator.java
@@ -52,7 +52,7 @@ public class ObjectFactoryGenerator {
     public ObjectFactoryGenerator(MapperFactory mapperFactory, ConstructorResolverStrategy constructorResolverStrategy,
     		CompilerStrategy compilerStrategy) {
         this.mapperFactory = mapperFactory;
-        this.nameSuffix = Integer.toHexString(System.identityHashCode(compilerStrategy));
+        this.nameSuffix = String.valueOf(System.nanoTime());
         this.constructorResolverStrategy = constructorResolverStrategy;
     }
     


### PR DESCRIPTION
Hi,

Once again I modified the ObjectFactoryGenerator.java class in order to improve the way object name suffix was being generated. Using System.nanoTime() the probability of concurrency issues is almost 0. I noticed the problem using JMeter executing 1000 calls within 1 second. This is way I cannot provide a test case but using JMeter it's easy to reproduce the problem. 

Please take a look at this since we are looking forward to use Orika on our production environment.

Thanks in advance

PS: This is the error trace that I used to get before my change:

ma.glasnost.orika.MappingException: ma.glasnost.orika.impl.generator.CompilerStrategy$SourceCodeGenerationException: javassist.CannotCompileException: by java.lang.LinkageError: loader (instance of  org/glassfish/web/loader/WebappClassLoader): attempted  duplicate class definition for name: "ma/glasnost/orika/generated/Orika_DivisionDTO_City_Mapper12381016"
    at ma.glasnost.orika.impl.generator.MapperGenerator.build(MapperGenerator.java:95)
    at ma.glasnost.orika.impl.DefaultMapperFactory.buildMapper(DefaultMapperFactory.java:1046)
    at ma.glasnost.orika.impl.DefaultMapperFactory.build(DefaultMapperFactory.java:910)
    at ma.glasnost.orika.impl.DefaultMapperFactory.getMapperFacade(DefaultMapperFactory.java:685)
    at ma.glasnost.orika.impl.ConfigurableMapper.<init>(ConfigurableMapper.java:105)
    at cl.groupon.api.common.mappers.Mapper.<init>(Mapper.java:9)
    at cl.groupon.api.output.mappers.CityMapper.<init>(CityMapper.java:20)
    at sun.reflect.GeneratedConstructorAccessor662.newInstance(Unknown Source)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:27)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:513)
    at org.jboss.weld.introspector.jlr.WeldConstructorImpl.newInstance(WeldConstructorImpl.java:206)
    at org.jboss.weld.injection.ConstructorInjectionPoint.newInstance(ConstructorInjectionPoint.java:117)
    at org.jboss.weld.bean.ManagedBean.createInstance(ManagedBean.java:336)
    at org.jboss.weld.bean.ManagedBean$ManagedBeanInjectionTarget.produce(ManagedBean.java:200)
    at org.jboss.weld.bean.ManagedBean.create(ManagedBean.java:292)
    at org.jboss.weld.context.unbound.DependentContextImpl.get(DependentContextImpl.java:68)
    at org.jboss.weld.manager.BeanManagerImpl.getReference(BeanManagerImpl.java:637)
    at org.jboss.weld.manager.BeanManagerImpl.getReference(BeanManagerImpl.java:703)
    at org.jboss.weld.injection.FieldInjectionPoint.inject(FieldInjectionPoint.java:136)
    at org.jboss.weld.util.Beans.injectBoundFields(Beans.java:686)
    at org.jboss.weld.util.Beans.injectFieldsAndInitializers(Beans.java:695)
    at org.jboss.weld.bean.ManagedBean$ManagedBeanInjectionTarget$1$1.proceed(ManagedBean.java:161)
    at org.glassfish.weld.services.InjectionServicesImpl.aroundInject(InjectionServicesImpl.java:134)
    at org.jboss.weld.injection.InjectionContextImpl.run(InjectionContextImpl.java:46)
    at org.jboss.weld.bean.ManagedBean$ManagedBeanInjectionTarget$1.work(ManagedBean.java:157)
    at org.jboss.weld.bean.ManagedBean$FixInjectionPoint.run(ManagedBean.java:131)
    at org.jboss.weld.bean.ManagedBean$ManagedBeanInjectionTarget.inject(ManagedBean.java:153)
    at org.jboss.weld.bean.ManagedBean.create(ManagedBean.java:293)
    at org.jboss.weld.context.AbstractContext.get(AbstractContext.java:107)
    at org.jboss.weld.bean.proxy.ContextBeanInstance.getInstance(ContextBeanInstance.java:90)
    at org.jboss.weld.bean.proxy.ProxyMethodHandler.invoke(ProxyMethodHandler.java:79)
    at cl.groupon.api.rest.DivisionsResource$Proxy$_$$_WeldClientProxy.getAllDivisions(DivisionsResource$Proxy$_$$_WeldClientProxy.java)
    at sun.reflect.GeneratedMethodAccessor481.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at com.sun.jersey.spi.container.JavaMethodInvokerFactory$1.invoke(JavaMethodInvokerFactory.java:60)
    at com.sun.jersey.server.impl.model.method.dispatch.AbstractResourceMethodDispatchProvider$TypeOutInvoker._dispatch(AbstractResourceMethodDispatchProvider.java:185)
    at com.sun.jersey.server.impl.model.method.dispatch.ResourceJavaMethodDispatcher.dispatch(ResourceJavaMethodDispatcher.java:75)
    at com.sun.jersey.server.impl.uri.rules.HttpMethodRule.accept(HttpMethodRule.java:288)
    at com.sun.jersey.server.impl.uri.rules.ResourceClassRule.accept(ResourceClassRule.java:108)
    at com.sun.jersey.server.impl.uri.rules.RightHandPathRule.accept(RightHandPathRule.java:147)
    at com.sun.jersey.server.impl.uri.rules.RootResourceClassesRule.accept(RootResourceClassesRule.java:84)
    at com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:1469)
    at com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:1400)
    at com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:1349)
    at com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:1339)
    at com.sun.jersey.spi.container.servlet.WebComponent.service(WebComponent.java:416)
    at com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:537)
    at com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:708)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:770)
    at org.apache.catalina.core.StandardWrapper.service(StandardWrapper.java:1550)
    at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:281)
    at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:175)
    at org.apache.catalina.core.StandardPipeline.doInvoke(StandardPipeline.java:655)
    at org.apache.catalina.core.StandardPipeline.invoke(StandardPipeline.java:595)
    at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:161)
    at org.apache.catalina.connector.CoyoteAdapter.doService(CoyoteAdapter.java:331)
    at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:231)
    at com.sun.enterprise.v3.services.impl.ContainerMapper$AdapterCallable.call(ContainerMapper.java:317)
    at com.sun.enterprise.v3.services.impl.ContainerMapper.service(ContainerMapper.java:195)
    at com.sun.grizzly.http.ProcessorTask.invokeAdapter(ProcessorTask.java:860)
    at com.sun.grizzly.http.ProcessorTask.doProcess(ProcessorTask.java:757)
    at com.sun.grizzly.http.ProcessorTask.process(ProcessorTask.java:1056)
    at com.sun.grizzly.http.DefaultProtocolFilter.execute(DefaultProtocolFilter.java:229)
    at com.sun.grizzly.DefaultProtocolChain.executeProtocolFilter(DefaultProtocolChain.java:137)
    at com.sun.grizzly.DefaultProtocolChain.execute(DefaultProtocolChain.java:104)
    at com.sun.grizzly.DefaultProtocolChain.execute(DefaultProtocolChain.java:90)
    at com.sun.grizzly.http.HttpProtocolChain.execute(HttpProtocolChain.java:79)
    at com.sun.grizzly.ProtocolChainContextTask.doCall(ProtocolChainContextTask.java:54)
    at com.sun.grizzly.SelectionKeyContextTask.call(SelectionKeyContextTask.java:59)
    at com.sun.grizzly.ContextTask.run(ContextTask.java:71)
    at com.sun.grizzly.util.AbstractThreadPool$Worker.doWork(AbstractThreadPool.java:532)
    at com.sun.grizzly.util.AbstractThreadPool$Worker.run(AbstractThreadPool.java:513)
    at java.lang.Thread.run(Thread.java:680)
Caused by: ma.glasnost.orika.impl.generator.CompilerStrategy$SourceCodeGenerationException: javassist.CannotCompileException: by java.lang.LinkageError: loader (instance of  org/glassfish/web/loader/WebappClassLoader): attempted  duplicate class definition for name: "ma/glasnost/orika/generated/Orika_DivisionDTO_City_Mapper12381016"
    at ma.glasnost.orika.impl.generator.JavassistCompilerStrategy.compileClass(JavassistCompilerStrategy.java:266)
    at ma.glasnost.orika.impl.generator.SourceCodeContext.compileClass(SourceCodeContext.java:214)
    at ma.glasnost.orika.impl.generator.SourceCodeContext.getInstance(SourceCodeContext.java:228)
    at ma.glasnost.orika.impl.generator.MapperGenerator.build(MapperGenerator.java:74)
    ... 73 more
Caused by: javassist.CannotCompileException: by java.lang.LinkageError: loader (instance of  org/glassfish/web/loader/WebappClassLoader): attempted  duplicate class definition for name: "ma/glasnost/orika/generated/Orika_DivisionDTO_City_Mapper12381016"
    at javassist.ClassPool.toClass(ClassPool.java:1099)
    at javassist.ClassPool.toClass(ClassPool.java:1042)
    at javassist.ClassPool.toClass(ClassPool.java:1000)
    at javassist.CtClass.toClass(CtClass.java:1140)
    at ma.glasnost.orika.impl.generator.JavassistCompilerStrategy.compileClass(JavassistCompilerStrategy.java:259)
    ... 76 more
Caused by: java.lang.LinkageError: loader (instance of  org/glassfish/web/loader/WebappClassLoader): attempted  duplicate class definition for name: "ma/glasnost/orika/generated/Orika_DivisionDTO_City_Mapper12381016"
    at java.lang.ClassLoader.defineClass1(Native Method)
    at java.lang.ClassLoader.defineClassCond(ClassLoader.java:631)
    at java.lang.ClassLoader.defineClass(ClassLoader.java:615)
    at java.lang.ClassLoader.defineClass(ClassLoader.java:465)
    at sun.reflect.GeneratedMethodAccessor413.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at javassist.ClassPool.toClass2(ClassPool.java:1112)
    at javassist.ClassPool.toClass(ClassPool.java:1093)
    ... 80 more
