### PR TITLE
lookupObjectFactory should consider superclasses for source type

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/impl/DefaultMapperFactory.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/DefaultMapperFactory.java
@@ -800,6 +800,9 @@ public class DefaultMapperFactory implements MapperFactory {
         		result = (ObjectFactory<T>) localCache.get(checkSourceType);
        			checkSourceType = checkSourceType.getSuperType();
         	} while (result == null && !TypeFactory.TYPE_OF_OBJECT.equals(checkSourceType));
+        	if (result == null) {
+        		result = (ObjectFactory<T>) localCache.get(TypeFactory.TYPE_OF_OBJECT);
+        	}
         }
         
         if (result == null) {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/PullRequest8TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/PullRequest8TestCase.java
@@ -1,0 +1,39 @@
+package ma.glasnost.orika.test.community;
+
+import ma.glasnost.orika.MapperFactory;
+import ma.glasnost.orika.ObjectFactory;
+import ma.glasnost.orika.impl.DefaultConstructorObjectFactory;
+import ma.glasnost.orika.metadata.TypeFactory;
+import ma.glasnost.orika.test.MappingUtil;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PullRequest8TestCase {
+	public static class MySourceType {
+	}
+
+	public static class MyType {
+	}
+
+	public static class MyObjectFactory<T> extends
+			DefaultConstructorObjectFactory<T> {
+		public MyObjectFactory(Class<T> type) {
+			super(type);
+		}
+	}
+
+	@Test
+	public void test() {
+		MapperFactory factory = MappingUtil.getMapperFactory();
+		factory.registerObjectFactory(
+				new MyObjectFactory<MyType>(MyType.class),
+				TypeFactory.valueOf(MyType.class));
+		factory.registerClassMap(factory.classMap(MySourceType.class,
+				MyType.class).toClassMap());
+		ObjectFactory<MyType> myFactory = factory.lookupObjectFactory(
+				TypeFactory.valueOf(MyType.class),
+				TypeFactory.valueOf(MySourceType.class));
+		Assert.assertTrue(myFactory instanceof MyObjectFactory);
+	}
+}


### PR DESCRIPTION
It is not possible to register an object factory for a destination type that should be used for all source types. The problem is that the superclasses of a source type are not taken into consideration. This patch allows registrations of object factories on superclasses of source types.
