### PR TITLE
Cleanup typeCache in MappingContext

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/MappingContext.java
+++ b/core/src/main/java/ma/glasnost/orika/MappingContext.java
@@ -40,7 +40,7 @@ public class MappingContext {
     
     private final Map<Type<?>, Type<?>> mapping;
     private final Map<java.lang.reflect.Type, Map<Object, Object>> classCache;
-    private final OpenIntObjectHashMap typeCache;
+    private OpenIntObjectHashMap typeCache;
     private List<Map<MapperKey, ClassMap<?, ?>>> mappersSeen;
     private Map<Object, Object> properties;
     private Map<Object, Object> globalProperties;
@@ -249,6 +249,7 @@ public class MappingContext {
      */
     public void reset() {
         classCache.clear();
+        typeCache = new OpenIntObjectHashMap();
         mapping.clear();
         if (properties != null) {
             properties.clear();

--- a/core/src/main/java/ma/glasnost/orika/metadata/Type.java
+++ b/core/src/main/java/ma/glasnost/orika/metadata/Type.java
@@ -40,7 +40,7 @@ public final class Type<T> implements ParameterizedType, Comparable<Type<?>> {
     private Type<?> componentType;
     private final TypeKey key;
     private final int hashCode;
-    private final AtomicInteger nextUniqueIndex = new AtomicInteger();
+    private static final AtomicInteger nextUniqueIndex = new AtomicInteger();
     private final int uniqueIndex;
 
     /**


### PR DESCRIPTION
The typeCache in MappingContext was never cleaned. This results in old objects being reused in later mappings. Also, the uniqueIndex in Type is not so unique, because it's always 0. nextUniqueIndex should have been static.
