### PR TITLE
Pl. include slf4j-log4j implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,12 @@
 			</dependency>
 
 			<dependency>
+		                <groupId>org.slf4j</groupId>
+		                <artifactId>slf4j-log4j12</artifactId>
+		                <version>${slf4j.version}</version>
+		         </dependency>
+		            
+			<dependency>
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-core</artifactId>
 				<version>${logback.version}</version>


### PR DESCRIPTION
log4j impl. is needed.. else it would break by saying 

Could not find method org.slf4j.impl.StaticLoggerBinder.getSingleton, referenced from method org.slf4j.LoggerFactory.bind