### PR TITLE
Provide more information when descending into nested objects.

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/MappingContext.java
+++ b/core/src/main/java/ma/glasnost/orika/MappingContext.java
@@ -232,9 +232,28 @@ public class MappingContext {
     
     /**
      * Mark the beginning of a particular mapping
+     *
+     * @deprecated This variant exists for backwards compatibility only; if overriding,
+     *             override {@link #beginMapping(Type, Object, Type, Object)} instead.
      */
     public void beginMapping() {
         ++depth;
+    }
+    
+    /**
+     * Mark the beginning of a particular mapping
+     *
+     * @param sourceType
+     *            the type of the source object being mapped
+     * @param source
+     *            the source object being mapped
+     * @param destType
+     *            the type of the destination object being mapped into
+     * @param dest
+     *            the destination object being mapped into
+     */
+    public void beginMapping(Type<?> sourceType, Object source, Type<?> destType, Object dest) {
+        beginMapping();
     }
     
     /**

--- a/core/src/main/java/ma/glasnost/orika/impl/mapping/strategy/UseConverterStrategy.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/mapping/strategy/UseConverterStrategy.java
@@ -49,6 +49,11 @@ public class UseConverterStrategy extends AbstractMappingStrategy {
         // TODO: mappingContext is not passed to converters, which could 
         //       be a problem with converters now (recently) having access
         //       to the MapperFacade; 
-        return converter.convert(unenhancer.unenhanceObject(sourceObject, sourceType), destinationType);
+        context.beginMapping(sourceType, sourceObject, destinationType, destinationObject);
+        try {
+            return converter.convert(unenhancer.unenhanceObject(sourceObject, sourceType), destinationType);
+        } finally {
+            context.endMapping();
+        }
     }
 }

--- a/core/src/main/java/ma/glasnost/orika/impl/mapping/strategy/UseCustomMapperStrategy.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/mapping/strategy/UseCustomMapperStrategy.java
@@ -54,17 +54,18 @@ public abstract class UseCustomMapperStrategy extends AbstractMappingStrategy {
     
     public Object map(final Object sourceObject, final Object destinationObject, final MappingContext context) {
         
-        context.beginMapping();
-        
         Object resolvedSourceObject = unenhancer.unenhanceObject(sourceObject, sourceType);
         
         Object newInstance = getInstance(resolvedSourceObject, destinationObject, context);
         
         context.cacheMappedObject(sourceObject, destinationType, newInstance);
         
-        customMapper.mapAtoB(resolvedSourceObject, newInstance, context);
-        
-        context.endMapping();
+        context.beginMapping(sourceType, resolvedSourceObject, destinationType, newInstance);
+        try {
+            customMapper.mapAtoB(resolvedSourceObject, newInstance, context);
+        } finally {
+            context.endMapping();
+        }
         
         return newInstance;
     }


### PR DESCRIPTION
MappingContext.beginMapping is now invoked for both customer-mappers as
well as custom-converters. Additionally, it is invoked with several
arguments that provide information about the mapping being started.

This implementation does not use the new information passed in; however,
it is now available to subclasses that need to do more tracking of the
current state.
