### PR TITLE
Massive perforance improvements for very large mappings

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/util/Edge.java
+++ b/core/src/main/java/ma/glasnost/orika/util/Edge.java
@@ -1,0 +1,27 @@
+package ma.glasnost.orika.util;
+
+class Edge<T> {
+	public final Node<T> from;
+	public final Node<T> to;
+
+	public Edge(Node<T> from, Node<T> to) {
+		this.from = from;
+		this.to = to;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		Edge<?> e = (Edge<?>) obj;
+		return e.from == from && e.to == to;
+	}
+
+	@Override
+	public int hashCode() {
+		return to.hashCode() ^ from.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return from.toString() + " -> " + to.toString();
+	}
+}

--- a/core/src/main/java/ma/glasnost/orika/util/Node.java
+++ b/core/src/main/java/ma/glasnost/orika/util/Node.java
@@ -1,0 +1,31 @@
+package ma.glasnost.orika.util;
+
+import java.util.LinkedHashSet;
+
+class Node<T> {
+	public final T value;
+	public final LinkedHashSet<Edge<T>> inEdges;
+	public final LinkedHashSet<Edge<T>> outEdges;
+
+	public Node(T value) {
+		this.value = value;
+		inEdges = new LinkedHashSet<Edge<T>>();
+		outEdges = new LinkedHashSet<Edge<T>>();
+	}
+
+	public Node<T> addEdge(Node<T> node) {
+		Edge<T> e = new Edge<T>(this, node);
+		outEdges.add(e);
+		node.inEdges.add(e);
+		return this;
+	}
+
+	public T getValue() {
+		return value;
+	}
+
+	@Override
+	public String toString() {
+		return getValue().toString();
+	}
+}

--- a/core/src/main/java/ma/glasnost/orika/util/SortedCollection.java
+++ b/core/src/main/java/ma/glasnost/orika/util/SortedCollection.java
@@ -20,8 +20,12 @@ package ma.glasnost.orika.util;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import ma.glasnost.orika.util.Ordering.OrderingRelation;
 
 /**
  * A simple sorted collection implementation that allows for duplicates; new
@@ -48,7 +52,13 @@ public class SortedCollection<V> implements Collection<V> {
 
 	private final ReentrantReadWriteLock rwl = new ReentrantReadWriteLock();
 
+	private final ReentrantReadWriteLock sortLock = new ReentrantReadWriteLock();
+
+	private Set<Node<V>> nodes = new LinkedHashSet<Node<V>>();
+
 	private List<V> items = new ArrayList<V>();
+
+	private volatile List<V> sortedItems = null;
 
 	/**
 	 * @param ordering
@@ -68,24 +78,61 @@ public class SortedCollection<V> implements Collection<V> {
 		addAll(c);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see java.util.Collection#add(java.lang.Object)
-	 */
 	public boolean add(V value) {
 		try {
 			rwl.writeLock().lock();
-			items.add(value);
-			items = TopologicalSorter.sort(filter(items), ordering);
-			return true;
+			if (mustAdd(value)) {
+				items.add(value);
+				Node<V> newNode = new Node<V>(value);
+				for (Node<V> from : nodes) {
+					final OrderingRelation order = ordering.order(
+							from.getValue(), newNode.getValue());
+					if (order == OrderingRelation.AFTER) {
+						from.addEdge(newNode);
+					} else if (order == OrderingRelation.BEFORE) {
+						newNode.addEdge(from);
+					}
+				}
+				nodes.add(newNode);
+				sortedItems = null;
+				return true;
+			}
+			return false;
 		} finally {
 			rwl.writeLock().unlock();
 		}
 	}
 
-	protected Collection<V> filter(List<V> items) {
-		return items;
+	protected boolean mustAdd(V item) {
+		return true;
+	}
+
+	public boolean remove(Object o) {
+		throw new UnsupportedOperationException();
+	}
+
+	public void clear() {
+		try {
+			rwl.writeLock().lock();
+			nodes.clear();
+			items.clear();
+			sortedItems = null;
+		} finally {
+			rwl.writeLock().unlock();
+		}
+	}
+
+	private List<V> getSortedItems() {
+		if (sortedItems == null) {
+			try {
+				sortLock.writeLock().lock();
+				if (sortedItems == null)
+					sortedItems = TopologicalSorter.sort(nodes);
+			} finally {
+				sortLock.writeLock().unlock();
+			}
+		}
+		return sortedItems;
 	}
 
 	public int size() {
@@ -106,25 +153,15 @@ public class SortedCollection<V> implements Collection<V> {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see java.lang.Iterable#iterator()
-	 */
 	public Iterator<V> iterator() {
 		try {
 			rwl.readLock().lock();
-			return new ArrayList<V>(items).iterator();
+			return getSortedItems().iterator();
 		} finally {
 			rwl.readLock().unlock();
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see java.util.Collection#contains(java.lang.Object)
-	 */
 	public boolean contains(Object o) {
 		try {
 			rwl.readLock().lock();
@@ -134,53 +171,24 @@ public class SortedCollection<V> implements Collection<V> {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see java.util.Collection#toArray()
-	 */
 	public Object[] toArray() {
 		try {
 			rwl.readLock().lock();
-			return items.toArray();
+			return getSortedItems().toArray();
 		} finally {
 			rwl.readLock().unlock();
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see java.util.Collection#toArray(T[])
-	 */
 	public <T> T[] toArray(T[] a) {
 		try {
 			rwl.readLock().lock();
-			return items.toArray(a);
+			return getSortedItems().toArray(a);
 		} finally {
 			rwl.readLock().unlock();
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see java.util.Collection#remove(java.lang.Object)
-	 */
-	public boolean remove(Object o) {
-		try {
-			rwl.writeLock().lock();
-			return items.remove(o);
-		} finally {
-			rwl.writeLock().unlock();
-		}
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see java.util.Collection#containsAll(java.util.Collection)
-	 */
 	public boolean containsAll(Collection<?> c) {
 		try {
 			rwl.readLock().lock();
@@ -190,62 +198,34 @@ public class SortedCollection<V> implements Collection<V> {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see java.util.Collection#addAll(java.util.Collection)
-	 */
 	public boolean addAll(Collection<? extends V> c) {
 		try {
 			rwl.writeLock().lock();
-			items.addAll(c);
-			items = TopologicalSorter.sort(filter(items), ordering);
-			return true;
+			boolean ret = false;
+			for (V curItem : c) {
+				ret |= add(curItem);
+			}
+			return ret;
 		} finally {
 			rwl.writeLock().unlock();
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see java.util.Collection#removeAll(java.util.Collection)
-	 */
 	public boolean removeAll(Collection<?> c) {
 		try {
 			rwl.writeLock().lock();
-			return items.removeAll(c);
+			boolean ret = false;
+			for (Object curItem : c) {
+				ret |= remove(curItem);
+			}
+			return ret;
 		} finally {
 			rwl.writeLock().unlock();
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see java.util.Collection#retainAll(java.util.Collection)
-	 */
 	public boolean retainAll(Collection<?> c) {
-		try {
-			rwl.writeLock().lock();
-			return items.retainAll(c);
-		} finally {
-			rwl.writeLock().unlock();
-		}
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see java.util.Collection#clear()
-	 */
-	public void clear() {
-		try {
-			rwl.writeLock().lock();
-			items.clear();
-		} finally {
-			rwl.writeLock().unlock();
-		}
+		throw new UnsupportedOperationException();
 	}
 
 	/**
@@ -254,19 +234,7 @@ public class SortedCollection<V> implements Collection<V> {
 	public V first() {
 		try {
 			rwl.readLock().lock();
-			return items.isEmpty() ? null : items.get(0);
-		} finally {
-			rwl.readLock().unlock();
-		}
-	}
-
-	/**
-	 * @return the last item in this collection
-	 */
-	public V last() {
-		try {
-			rwl.readLock().lock();
-			return items.isEmpty() ? null : items.get(items.size() - 1);
+			return items.isEmpty() ? null : getSortedItems().get(0);
 		} finally {
 			rwl.readLock().unlock();
 		}

--- a/core/src/main/java/ma/glasnost/orika/util/SortedSet.java
+++ b/core/src/main/java/ma/glasnost/orika/util/SortedSet.java
@@ -18,8 +18,6 @@
 package ma.glasnost.orika.util;
 
 import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -56,7 +54,8 @@ public class SortedSet<V> extends SortedCollection<V> implements Set<V> {
 		super(c, ordering);
 	}
 
-	protected Collection<V> filter(List<V> items) {
-		return new LinkedHashSet<V>(items);
+	@Override
+	protected boolean mustAdd(V item) {
+		return !super.contains(item);
 	}
 }

--- a/core/src/main/java/ma/glasnost/orika/util/TopologicalSorter.java
+++ b/core/src/main/java/ma/glasnost/orika/util/TopologicalSorter.java
@@ -20,90 +20,27 @@ package ma.glasnost.orika.util;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import ma.glasnost.orika.util.Ordering.OrderingRelation;
+public class TopologicalSorter<V> {
 
-public class TopologicalSorter {
-
-	private static class Node<T> {
-		public final T value;
-		public final LinkedHashSet<Edge<T>> inEdges;
-		public final LinkedHashSet<Edge<T>> outEdges;
-
-		public Node(T value) {
-			this.value = value;
-			inEdges = new LinkedHashSet<Edge<T>>();
-			outEdges = new LinkedHashSet<Edge<T>>();
-		}
-
-		public Node<T> addEdge(Node<T> node) {
-			Edge<T> e = new Edge<T>(this, node);
-			outEdges.add(e);
-			node.inEdges.add(e);
-			return this;
-		}
-
-		public T getValue() {
-			return value;
-		}
-
-		@Override
-		public String toString() {
-			return getValue().toString();
-		}
-	}
-
-	private static class Edge<T> {
-		public final Node<T> from;
-		public final Node<T> to;
-
-		public Edge(Node<T> from, Node<T> to) {
-			this.from = from;
-			this.to = to;
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			Edge<?> e = (Edge<?>) obj;
-			return e.from == from && e.to == to;
-		}
-		
-		@Override
-		public int hashCode() {
-			return to.hashCode() ^ from.hashCode();
-		}
-
-		@Override
-		public String toString() {
-			return from.toString() + " -> " + to.toString();
-		}
-	}
-
-	public static <T> List<T> sort(Collection<T> elements, Ordering<T> ordering) {
-		List<Node<T>> nodes = new ArrayList<Node<T>>();
-		for (T curElement : elements)
-			nodes.add(new Node<T>(curElement));
-
-		// Empty list that will contain the sorted elements
-		ArrayList<T> result = new ArrayList<T>();
-
+	public static <T> List<T> sort(Collection<Node<T>> nodes) {
 		// Set of all nodes with no incoming edges
 		Set<Node<T>> openSet = new LinkedHashSet<Node<T>>();
+		Set<Edge<T>> edgesDone = new HashSet<Edge<T>>();
 
 		for (Node<T> to : nodes) {
-			for (Node<T> from : nodes) {
-				if (ordering.order(from.getValue(), to.getValue()) == OrderingRelation.AFTER) {
-					from.addEdge(to);
-				}
-			}
 			if (to.inEdges.isEmpty()) {
 				openSet.add(to);
 			}
 		}
+
+		// Empty list that will contain the sorted elements
+		ArrayList<T> result = new ArrayList<T>();
 
 		// while openSet is non-empty do
 		while (!openSet.isEmpty()) {
@@ -116,15 +53,16 @@ public class TopologicalSorter {
 
 			// for each node m with an edge e from n to m do
 			for (Iterator<Edge<T>> it = n.outEdges.iterator(); it.hasNext();) {
-				// remove edge e from the graph
 				Edge<T> e = it.next();
-				Node<T> m = e.to;
-				it.remove();// Remove edge from n
-				m.inEdges.remove(e);// Remove edge from m
+				if (!edgesDone.contains(e)) {
+					// remove edge e from the graph
+					Node<T> m = e.to;
+					edgesDone.add(e);// Remove edge from m (mark it done)
 
-				// if m has no other incoming edges then insert m into S
-				if (m.inEdges.isEmpty()) {
-					openSet.add(m);
+					// if m has no other incoming edges then insert m into S
+					if (edgesDone.containsAll(m.inEdges)) {
+						openSet.add(m);
+					}
 				}
 			}
 		}

--- a/tests/src/main/java/ma/glasnost/orika/test/util/SortedCollectionTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/util/SortedCollectionTestCase.java
@@ -17,19 +17,18 @@
  */
 package ma.glasnost.orika.test.util;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
-import org.junit.Assert;
 import ma.glasnost.orika.metadata.MapperKey;
 import ma.glasnost.orika.metadata.TypeFactory;
 import ma.glasnost.orika.util.Ordering;
+import ma.glasnost.orika.util.Ordering.OrderingRelation;
 import ma.glasnost.orika.util.SortedCollection;
-import ma.glasnost.orika.util.TopologicalSorter;
 
-import org.eclipse.jdt.internal.compiler.ast.OR_OR_Expression;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -120,27 +119,24 @@ public class SortedCollectionTestCase {
     
     @Test
     public void simpleOrdering() {
+    	final OrderingRelation[][] relations = new OrderingRelation[][] {
+    		{ OrderingRelation.EQUAL, OrderingRelation.AFTER, OrderingRelation.UNDEFINED, OrderingRelation.UNDEFINED },
+    		{ OrderingRelation.BEFORE, OrderingRelation.EQUAL, OrderingRelation.AFTER, OrderingRelation.UNDEFINED },
+    		{ OrderingRelation.UNDEFINED, OrderingRelation.BEFORE, OrderingRelation.EQUAL, OrderingRelation.AFTER },
+    		{ OrderingRelation.UNDEFINED, OrderingRelation.UNDEFINED, OrderingRelation.BEFORE, OrderingRelation.EQUAL }
+    	};
 		Ordering<Integer> testOrdering = new Ordering<Integer>() {
 			@Override
 			public OrderingRelation order(Integer object1, Integer object2) {
 				int val1 = object1;
 				int val2 = object2;
-				if (val1 == val2)
-					return OrderingRelation.EQUAL;
-				
-				switch (val1) {
-				case 0:
-					return val2 == 1 || val2 == 2 ? OrderingRelation.AFTER : OrderingRelation.UNDEFINED;
-				case 1:
-					return val2 == 2 || val2 == 3 ? OrderingRelation.AFTER : OrderingRelation.UNDEFINED;
-				case 2:
-					return val2 == 3 ? OrderingRelation.AFTER : OrderingRelation.UNDEFINED;
-				}
-				return OrderingRelation.UNDEFINED;
+				return relations[val1][val2];
 			}
 		};
-		List<Integer> sorted = TopologicalSorter.sort(Arrays.asList(3, 1, 0, 2), testOrdering);
-		Assert.assertEquals(Arrays.asList(0, 1, 2, 3), sorted);
+		SortedCollection<Integer> sorted = new SortedCollection<Integer>(
+				Arrays.asList(3, 1, 0, 2), testOrdering);
+		Assert.assertEquals(Arrays.asList(0, 1, 2, 3), new ArrayList<Integer>(
+				sorted));
     }
     
     @Test


### PR DESCRIPTION
The current implementation of SortedCollection (with TopologicalSorter) is very expensive when dealing with larger sets (>1000 entries). This is mainly caused by the fact that SortedCollection re-sorts the entire collection for every element added, including determining the ordering relations. This implementation keeps track of ordering relations for all elements while they are being added and only sorts when needed. In our project, this reduced the processing time by a factor 10.
