### PR TITLE
Added optional deferred initialisation to ConfigurableMapper

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/impl/ConfigurableMapper.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/ConfigurableMapper.java
@@ -84,24 +84,34 @@ import ma.glasnost.orika.metadata.Type;
  */
 public class ConfigurableMapper implements MapperFacade {
 
-    private final MapperFacade facade;
-    private final DefaultMapperFactory factory;
-    
-    protected ConfigurableMapper() {
-        
+    private MapperFacade facade;
+    private DefaultMapperFactory factory;
+      
+    public ConfigurableMapper() {
+        init();  
+    }
+     
+    public ConfigurableMapper(boolean autoInit) {
+        if (autoInit) {
+            init();  
+        }
+    }
+     
+    protected void init() {
+       
         DefaultMapperFactory.Builder factoryBuilder = new DefaultMapperFactory.Builder();
         /*
          * Apply optional user customizations to the factory builder
          */
         configureFactoryBuilder(factoryBuilder);
-        
+           
         factory = factoryBuilder.build();
-        
+           
         /*
          * Apply customizations/configurations
          */
         configure(factory);
-        
+         
         facade = factory.getMapperFacade();
     }
    


### PR DESCRIPTION
Deferring intialisation to after constructor completes allows subclasses to capture their own constructor arguments before the MapperFacade is created, and therefore allow runtime control over the Mapper's behaviour (e.g. caller can pass in a list of config files to use as the basis of the initialisation).
