### PR TITLE
Fix bug in Convert

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/impl/generator/specification/Convert.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/specification/Convert.java
@@ -51,7 +51,7 @@ public class Convert extends AbstractSpecification {
             if (destination.type().isPrimitive() && source.type().isPrimitive()) {
                 return format("(%s == %s)", destination, source);
             } else if (destination.type().isPrimitive()) {
-                return format("(%s != null && %s == %s.%sValue())", source, destination, source,  source.type().getName());
+                return format("(%s != null && %s == %s.%sValue())", source, destination, source,  destination.type().getPrimitiveType().getName());
             } else if (source.type().isPrimitive()) {
                 return format("(%s != null && %s.%sValue() == %s)", destination, destination, destination.type().getPrimitiveType().getName(), source);
             } else {


### PR DESCRIPTION
In debug mode I have: 
source: ((java.lang.Boolean)attribute_source0Element.getVisible())
destenation: ((boolean)((com.macys.platform.services.navigation.dto.AttributeDTO)_destination0Element.getValue()).isVisible())
We can see that destenation primitive and source Boolean (Object)
But in result generated code: (((java.lang.Boolean)attribute_source0Element.getVisible()) != null && ((boolean)((com.macys.platform.services.navigation.dto.AttributeDTO)_destination0Element.getValue()).isVisible()) == ((java.lang.Boolean)attribute_source0Element.getVisible()).java.lang.BooleanValue())
which not complied.

Should be:
(((java.lang.Boolean)attribute_source0Element.getVisible()) != null && ((boolean)((com.macys.platform.services.navigation.dto.AttributeDTO)_destination0Element.getValue()).isVisible()) == ((java.lang.Boolean)attribute_source0Element.getVisible()).booleanValue())
