### PR TITLE
Initialize usedMappers before checking

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/impl/DefaultMapperFactory.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/DefaultMapperFactory.java
@@ -1304,6 +1304,14 @@ public class DefaultMapperFactory implements MapperFactory, Reportable {
         
         parentMappers.remove(mapper);
         
+        for (Mapper<Object, Object> curParrentMapper : parentMappers) {
+            if (!GeneratedMapperBase.isUsedMappersInitialized(curParrentMapper)) {
+                initializeUsedMappers(getClassMap(new MapperKey(
+                        curParrentMapper.getAType(),
+                        curParrentMapper.getBType())));
+            }
+        }
+
         /*
          * De-duplicate used mappers within the hierarchy
          * TODO: need to find a consistent way to avoid creating

--- a/core/src/main/java/ma/glasnost/orika/impl/GeneratedMapperBase.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/GeneratedMapperBase.java
@@ -40,6 +40,16 @@ public abstract class GeneratedMapperBase extends GeneratedObjectBase implements
     public static boolean isUsedMapperOf(Mapper<Object, Object> usedMapper, Mapper<Object, Object> ofMapper) {
         return (ofMapper instanceof GeneratedMapperBase && ((GeneratedMapperBase) ofMapper).uses(usedMapper));
     }
+
+    /**
+     * Returns true if the <code>usedMappers</code>-array of the given mapper is initialized.
+     *
+     * @param mapper the mapper to check
+     * @return
+     */
+    public static boolean isUsedMappersInitialized(Mapper<Object, Object> mapper) {
+        return (mapper instanceof GeneratedMapperBase && ((GeneratedMapperBase) mapper).getUsedMappers() != null);
+    }
     
     protected Mapper<Object, Object> customMapper;
     private Mapper<Object, Object>[] usedMappers;


### PR DESCRIPTION
The initialization of usedMappers tries to prevent duplicates within the mapper hierarchy, but searches for these duplicates in mappers that may not yet have been initialized. This simple check makes sure that the parent mappers have the usedMappers array initialized before checking for duplicates.
