### PR TITLE
One more Fix java8

### DIFF
--- a/eclipse-tools/pom.xml
+++ b/eclipse-tools/pom.xml
@@ -31,11 +31,11 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.eclipse.jdt</groupId>
-			<artifactId>org.eclipse.jdt.core</artifactId>
-			<version>3.7.1</version>
-		</dependency>
+        <dependency>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>org.eclipse.jdt.core</artifactId>
+            <version>3.10.0.v20140604-1726</version>
+        </dependency>
 
 		<dependency>
 			<groupId>org.eclipse.text</groupId>
@@ -43,26 +43,8 @@
 			<version>3.5.101</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.eclipse.core</groupId>
-			<artifactId>org.eclipse.core.runtime</artifactId>
-			<version>3.7.0</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.eclipse.equinox</groupId>
-					<artifactId>org.eclipse.core.app</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
 
-		<dependency>
-			<groupId>org.eclipse.core</groupId>
-			<artifactId>org.eclipse.core.resources</artifactId>
-			<version>3.7.100</version>
-		</dependency>
-
-
-	</dependencies>
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/eclipse-tools/src/main/java/ma/glasnost/orika/impl/generator/eclipsejdt/CompilationUnit.java
+++ b/eclipse-tools/src/main/java/ma/glasnost/orika/impl/generator/eclipsejdt/CompilationUnit.java
@@ -65,4 +65,8 @@ public class CompilationUnit implements ICompilationUnit {
 		}
 		return result;
 	}
+
+    public boolean ignoreOptionalProblems() {
+        return true;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<javassist.version>3.16.1-GA</javassist.version>
+		<javassist.version>3.18.2-GA</javassist.version>
 		<springframework.version>3.1.1.RELEASE</springframework.version>
 		<hibernate.version>3.3.2.GA</hibernate.version>
 		<junit.version>4.11</junit.version>


### PR DESCRIPTION
One more proposition java8 Fix. I saw that you have already tried to use new eclipse jdt (org.eclipse.tycho). But, I don't know why you revert this changes. Now I have a build with this changes in my orika-fork https://github.com/jad7/orika/ and you can see, that my Travis build is a green https://travis-ci.org/jad7/orika/ with this changes on jdk7 and jdk8. I think, it's should fix main build.
