### PR TITLE
Fix for Issue 129 AdHoc Properties with only getter or setter

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/property/PropertyResolver.java
+++ b/core/src/main/java/ma/glasnost/orika/property/PropertyResolver.java
@@ -706,8 +706,9 @@ public abstract class PropertyResolver implements PropertyResolverStrategy {
         }
     }
 
-    private static final Pattern INLINE_PROPERTY_PATTERN = Pattern.compile("([\\w]+)\\:\\{\\s*([\\w\\(\\)'\"\\% ]+)\\s*\\|\\s*([\\w\\(\\)'\"\\%, ]+)\\s*\\|?\\s*(?:(?:type=)([\\w.\\$ \\<\\>]+))?\\}");
-    
+    private static final Pattern INLINE_PROPERTY_PATTERN = Pattern.compile("([\\w]+)\\:\\{(?:\\s*([\\w\\(\\)'\\\"\\% ]+))?\\s*(?:\\|\\s*([\\w\\(\\)'\\\"\\%, ]+)\\s*)?(?:\\|?\\s*(?:type=)([\\w.\\$ \\<\\>]+))?\\}");
+
+
     /**
      * Determines whether the provided string is a valid in-line property
      * expression
@@ -717,7 +718,8 @@ public abstract class PropertyResolver implements PropertyResolverStrategy {
      * @return true if the expression represents an in-line property
      */
     protected boolean isInlinePropertyExpression(String expression) {
-        return INLINE_PROPERTY_PATTERN.matcher(expression).matches();
+        Matcher matcher = INLINE_PROPERTY_PATTERN.matcher(expression);
+        return matcher.matches() && (matcher.group(2) != null || matcher.group(3) != null);
     }
     
     /**
@@ -747,8 +749,12 @@ public abstract class PropertyResolver implements PropertyResolverStrategy {
         
         if (matcher.matches()) {
             Property.Builder builder = new Property.Builder(theType, matcher.group(1));
-            builder.getter(matcher.group(2));
-            builder.setter(matcher.group(3));
+            if (matcher.group(2) != null) {
+                builder.getter(matcher.group(2));
+            }
+            if (matcher.group(3) != null) {
+                builder.setter(matcher.group(3));
+            }
             builder.type(matcher.group(4));
             return builder.build(this);
         } else {

--- a/tests/src/main/java/ma/glasnost/orika/test/property/PropertyResolverTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/property/PropertyResolverTestCase.java
@@ -160,13 +160,56 @@ public class PropertyResolverTestCase {
 	    Assert.assertEquals("name.firstName", prop.getExpression());
 	    Assert.assertEquals(TypeFactory.valueOf(String.class), prop.getType());
 	}
-	
+
+    @Test
+    public void testAdHocResolutionGetterOnly() {
+
+        Property prop = propertyResolver.getProperty(A.class, "name:{readTheNameForThisBean}.firstName");
+
+        Assert.assertNotNull(prop);
+        Assert.assertEquals("firstName", prop.getName());
+        Assert.assertEquals("name.firstName", prop.getExpression());
+        Assert.assertEquals(TypeFactory.valueOf(String.class), prop.getType());
+    }
+
+    @Test
+    public void testAdHocResolutionSetterOnly() {
+
+        Property prop = propertyResolver.getProperty(A.class, "name:{|assignTheName}.firstName");
+
+        Assert.assertNotNull(prop);
+        Assert.assertEquals("firstName", prop.getName());
+        Assert.assertEquals("name.firstName", prop.getExpression());
+        Assert.assertEquals(TypeFactory.valueOf(String.class), prop.getType());
+    }
 	
 	@Test
     public void testAdHocResolution_withType() {
         
         Property prop = propertyResolver.getProperty(A.class, "name:{readTheNameForThisBean|assignTheName|type=ma.glasnost.orika.test.property.TestCaseClasses$Name}.firstName");
         
+        Assert.assertNotNull(prop);
+        Assert.assertEquals("firstName", prop.getName());
+        Assert.assertEquals("name.firstName", prop.getExpression());
+        Assert.assertEquals(TypeFactory.valueOf(String.class), prop.getType());
+    }
+
+    @Test
+    public void testAdHocResolutionGetterOnly_withType() {
+
+        Property prop = propertyResolver.getProperty(A.class, "name:{readTheNameForThisBean|type=ma.glasnost.orika.test.property.TestCaseClasses$Name}.firstName");
+
+        Assert.assertNotNull(prop);
+        Assert.assertEquals("firstName", prop.getName());
+        Assert.assertEquals("name.firstName", prop.getExpression());
+        Assert.assertEquals(TypeFactory.valueOf(String.class), prop.getType());
+    }
+
+    @Test
+    public void testAdHocResolutionSetterOnly_withType() {
+
+        Property prop = propertyResolver.getProperty(A.class, "name:{|assignTheName|type=ma.glasnost.orika.test.property.TestCaseClasses$Name}.firstName");
+
         Assert.assertNotNull(prop);
         Assert.assertEquals("firstName", prop.getName());
         Assert.assertEquals("name.firstName", prop.getExpression());


### PR DESCRIPTION
Fix for Issue 129 AdHoc Properties with only getter or setter including Test Case
https://code.google.com/p/orika/issues/detail?id=129

The earlier pull request was based on an old commit so I created a new clean one.
