### PR TITLE
Allow to specify values in Map collections not only with string keys

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/metadata/ClassMapBuilderForMaps.java
+++ b/core/src/main/java/ma/glasnost/orika/metadata/ClassMapBuilderForMaps.java
@@ -195,7 +195,7 @@ public class ClassMapBuilderForMaps<A, B> extends ClassMapBuilder<A,B> {
             mapAncestor = mapAncestor.findAncestor(Map.class);
         }
         
-        return new MapKeyProperty(expr, mapAncestor.getNestedType(1), null);
+        return new MapKeyProperty(expr, mapAncestor.getNestedType(0), mapAncestor.getNestedType(1), null);
     }
     
 }

--- a/core/src/main/java/ma/glasnost/orika/metadata/MapKeyProperty.java
+++ b/core/src/main/java/ma/glasnost/orika/metadata/MapKeyProperty.java
@@ -26,8 +26,14 @@ package ma.glasnost.orika.metadata;
  */
 public class MapKeyProperty extends Property {
     
-    public MapKeyProperty(String key, Type<?> type, Property owner) {
-        super(key,key,"get(\"" + key + "\")","put(\"" + key + "\",%s)",type,null, owner);
+    public MapKeyProperty(String key, Type<?> keyType, Type<?> valueType, Property owner) {
+        super(key,key,"get(" + chooseKey(key, keyType) + ")","put(" + chooseKey(key, keyType) + ",%s)",valueType,null, owner);
+    }
+
+    static private String chooseKey(String key, Type<?> keyType) {
+        return (String.class != keyType.getRawType() && keyType.isConvertibleFromString())
+            ?   keyType.getCanonicalName() + ".valueOf(\"" + key + "\")"
+            :   "\"" + key + "\"";
     }
     
     public boolean isMapKey() {

--- a/core/src/main/java/ma/glasnost/orika/property/PropertyResolver.java
+++ b/core/src/main/java/ma/glasnost/orika/property/PropertyResolver.java
@@ -579,7 +579,7 @@ public abstract class PropertyResolver implements PropertyResolverStrategy {
         if (owningProperty.isMap()) {
             elementType = MapEntry.concreteEntryType((Type<Map<Object, Object>>) owningProperty.getType());
             String key = elementPropertyExpression.substring(1, elementPropertyExpression.length()-1);
-            elementProperty = new MapKeyProperty(key, elementType.getNestedType(1), null); 
+            elementProperty = new MapKeyProperty(key, elementType.getNestedType(0), elementType.getNestedType(1), null);
         } else if (owningProperty.isCollection()) {
             elementType = owningProperty.getType().getNestedType(0);
             try {

--- a/tests/src/main/java/ma/glasnost/orika/test/generator/BeanToMapGenerationTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/generator/BeanToMapGenerationTestCase.java
@@ -229,8 +229,76 @@ public class BeanToMapGenerationTestCase {
         Assert.assertEquals(person.father.last, mapBack.father.last);
             
     }
-	
-	public static class Person {
+
+    @Test
+    public void testNestedMapElementWithIntegerKey() {
+
+
+        MapperFactory factory = MappingUtil.getMapperFactory();
+
+        Type<Map<Integer, String>> mapType = new TypeBuilder<Map<Integer, String>>(){}.build();
+        Type<Name> nameType = TypeFactory.valueOf(Name.class);
+
+        factory.classMap(Name.class, mapType)
+                .field("first", "['0']")
+                .field("last", "['42']")
+                .byDefault()
+                .register();
+
+        MapperFacade mapper = factory.getMapperFacade();
+
+        Name name = new Name();
+        name.first = "Any First Name";
+        name.last = "Any Last Name";
+
+        Map<Integer, String> result = mapper.map(name, nameType, mapType);
+
+        Assert.assertEquals(name.first, result.get(0));
+        Assert.assertEquals(name.last, result.get(42));
+
+        Name mapBack = mapper.map(result, mapType, nameType);
+
+        Assert.assertEquals(name.first, mapBack.first);
+        Assert.assertEquals(name.last, mapBack.last);
+    }
+
+    @Test
+    public void testNestedMapElementWithEnumKey() {
+
+
+        MapperFactory factory = MappingUtil.getMapperFactory();
+
+        Type<Map<NameFields, String>> mapType = new TypeBuilder<Map<NameFields, String>>(){}.build();
+        Type<Name> nameType = TypeFactory.valueOf(Name.class);
+
+        factory.classMap(Name.class, mapType)
+                .field("first", "['FIRST']")
+                .field("last", "['LAST']")
+                .byDefault()
+                .register();
+
+        MapperFacade mapper = factory.getMapperFacade();
+
+        Name name = new Name();
+        name.first = "Any First Name";
+        name.last = "Any Last Name";
+
+        Map<NameFields, String> result = mapper.map(name, nameType, mapType);
+
+        Assert.assertEquals(name.first, result.get(NameFields.FIRST));
+        Assert.assertEquals(name.last, result.get(NameFields.LAST));
+
+        Name mapBack = mapper.map(result, mapType, nameType);
+
+        Assert.assertEquals(name.first, mapBack.first);
+        Assert.assertEquals(name.last, mapBack.last);
+    }
+
+    public static enum NameFields {
+        FIRST, LAST;
+    }
+
+    public static class Person {
 	    public Name name;
 	    public Name father;
 	}


### PR DESCRIPTION
There is a possibility to access Map values like this:

``` java
factory.classMap(SomeClass.class, TypeFactory.valueOf(Map.class, String.class, String.class))
    .field("classField", "['ValueOfTheMap']")
```

However it works only for Maps with string keys. This pull request fixes it, trying to convert the string provided in quotes ('ValueOfTheMap' in example above) to the Map key type (using valueOf() if it is available). So it would be possible to write something like this:

``` java
factory.classMap(SomeClass.class, TypeFactory.valueOf(Map.class, Integer.class, String.class))
    .field("classField", "['0']");

factory.classMap(SomeClass.class, TypeFactory.valueOf(Map.class, SomeEnumType.class, String.class))
    .field("classField", "['ENUM_VALUE']")
```
