### PR TITLE
Update to use Javassist  3.19.0-GA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<javassist.version>3.18.2-GA</javassist.version>
+		<javassist.version>3.19.0-GA</javassist.version>
 		<springframework.version>3.1.1.RELEASE</springframework.version>
 		<hibernate.version>3.3.2.GA</hibernate.version>
 		<junit.version>4.11</junit.version>


### PR DESCRIPTION
Javassist 3.19.0-GA adds Java 8 support

https://github.com/jboss-javassist/javassist/releases/tag/rel_3_19_0_ga