### PR TITLE
Orika 1.5.x - remove "/eclipse-tools/.settings" and update JDK version 1.6

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/metadata/TypeUtil.java
+++ b/core/src/main/java/ma/glasnost/orika/metadata/TypeUtil.java
@@ -96,7 +96,9 @@ abstract class TypeUtil {
                         } catch (IllegalArgumentException e) {
                             defaultTypeArguments[i] = typeFromArgument;
                         }
-                        hasUnresolvedTypes = true;
+                        if (defaultTypeArguments[i] == null || defaultTypeArguments[i].equals(TypeFactory.TYPE_OF_OBJECT)) {
+                            hasUnresolvedTypes = true;
+                        }
                     }
                 }
             }

--- a/eclipse-tools/.settings/org.eclipse.jdt.core.prefs
+++ b/eclipse-tools/.settings/org.eclipse.jdt.core.prefs
@@ -1,6 +1,0 @@
-#Sat Sep 29 13:38:06 PDT 2012
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.source=1.5

--- a/eclipse-tools/.settings/org.eclipse.m2e.core.prefs
+++ b/eclipse-tools/.settings/org.eclipse.m2e.core.prefs
@@ -1,5 +1,0 @@
-#Sat Sep 29 13:38:00 PDT 2012
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/pom.xml
+++ b/pom.xml
@@ -312,8 +312,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.2</version>
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>1.6</source>
+					<target>1.6</target>
 				</configuration>
 			</plugin>
 

--- a/tests/src/main/java/ma/glasnost/orika/test/custommapper/CustomMappingTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/custommapper/CustomMappingTestCase.java
@@ -18,6 +18,11 @@
 
 package ma.glasnost.orika.test.custommapper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Collection;
+
 import ma.glasnost.orika.CustomMapper;
 import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.MappingContext;
@@ -70,9 +75,41 @@ public class CustomMappingTestCase {
         Assert.assertEquals(dto.getName(), person.getFirstName() + " " + person.getLastName());
     }
     
-    public static class CustomPersonMapper<D> extends CustomMapper<D, Person> {
-        
+    @Test
+    public void testCustomGenericCollectionMapping() {
+        CustomGenericCollectionMapper mapper = new CustomGenericCollectionMapper();
+
+        assertThat(mapper.getAType().toString(), is("Collection<PersonDTO>"));
+        assertThat(mapper.getBType().toString(), is("Collection<Person>"));
     }
+    
+    @Test
+    public void testCustomCollectionWildcardMapping() {
+        CustomCollectionWithWildcardsMapper mapper = new CustomCollectionWithWildcardsMapper();
+
+        assertThat(mapper.getAType().toString(), is("Collection<Object>")); // ? super PersonDTO
+        assertThat(mapper.getBType().toString(), is("Collection<Person>")); // ? extends Person
+    }
+    @Test
+    public void testCustomDeepInheritedMapping() {
+        CustomDeepInheritedPersonMapper mapper = new CustomDeepInheritedPersonMapper();
+
+        assertThat(mapper.getAType().toString(), is("PersonDTO"));
+        assertThat(mapper.getBType().toString(), is("Person"));
+    }
+
+    public static class CustomCollectionWithWildcardsMapper
+            extends CustomMapper<Collection<? super PersonDTO>, Collection<? extends Person>> {/* do nothing impl */}
+    
+    public static class CustomGenericCollectionMapper
+            extends CustomMapper<Collection<PersonDTO>, Collection<Person>> {/* do nothing impl */}
+    
+    public static class CustomPersonMapper<D> extends CustomMapper<D, Person> {/* do nothing impl */}
+    
+    public static class CustomInheritedPersonMapper extends CustomPersonMapper<PersonDTO> {/* do nothing impl */}
+    
+    public static class CustomDeepInheritedPersonMapper extends CustomInheritedPersonMapper {/* do nothing impl */}
+    
     
     public static class PersonDTO {
         private String name;


### PR DESCRIPTION
I will start with the first point of (MappingContext should only initialized and release one time per mapping graph)
https://groups.google.com/forum/#!topic/orika-discuss/C0j6zdYdZOg

But first:
 * I remove the "/eclipse-tools/.settings" folder (I believe it was a mistake)
 * Update JDK Version to 1.6 because the project dosn't compile with JDK 1.5:  
    because Collections.newSetFromMap(...) in VariableRef.java [54] exists only since JDK 1.6

thanks,
Harald
