### PR TITLE
Orika 1.5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk:
+  - openjdk6
   - oraclejdk7
   - oraclejdk8
 branches:

--- a/core/src/main/java/ma/glasnost/orika/metadata/TypeFactory.java
+++ b/core/src/main/java/ma/glasnost/orika/metadata/TypeFactory.java
@@ -304,31 +304,18 @@ public abstract class TypeFactory {
      * @return the resolved Type instance
      */
     private static Type<?> refineBounds(Set<Type<?>> bounds) {
-        if (bounds.size() > 1) {
-            // Consolidate bounds to most significant
-            Iterator<Type<?>> currentBoundIter = bounds.iterator();
-            while (currentBoundIter.hasNext()) {
-                Type<?> currentBound = currentBoundIter.next();
-                Iterator<Type<?>> boundIter = bounds.iterator();
-                while (boundIter.hasNext()) {
-                    Type<?> nextType = boundIter.next();
-                    if (nextType.equals(currentBound)) {
-                        continue;
-                    } else {
-                        Type<?> mostSpecific = TypeUtil.getMostSpecificType(currentBound, nextType);
-                        if (nextType.equals(mostSpecific)) {
-                            boundIter.remove();
-                        }
-                    }
-                    
-                }
-            }
-            if (bounds.size() != 1) {
-                throw new IllegalArgumentException(bounds + " is not refinable");
+        // Consolidate bounds to most significant
+        Type<?> currentMostSpecific = null;
+        Iterator<Type<?>> currentBoundIter = bounds.iterator();
+        while (currentBoundIter.hasNext()) {
+            Type<?> currentBound = currentBoundIter.next();
+            if (currentMostSpecific == null) {
+                currentMostSpecific = currentBound;
+            } else {
+                currentMostSpecific = TypeUtil.getMostSpecificType(currentMostSpecific, currentBound);
             }
         }
-        
-        return bounds.iterator().next();
+        return currentMostSpecific;
     }
     
     /**

--- a/tests/src/main/java/ma/glasnost/orika/test/custommapper/CustomMappingTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/custommapper/CustomMappingTestCase.java
@@ -87,7 +87,7 @@ public class CustomMappingTestCase {
     public void testCustomCollectionWildcardMapping() {
         CustomCollectionWithWildcardsMapper mapper = new CustomCollectionWithWildcardsMapper();
 
-        assertThat(mapper.getAType().toString(), is("Collection<Object>")); // ? super PersonDTO
+        assertThat(mapper.getAType().toString(), is("Collection<PersonDTO>")); // ? super PersonDTO
         assertThat(mapper.getBType().toString(), is("Collection<Person>")); // ? extends Person
     }
     @Test

--- a/tests/src/main/java/ma/glasnost/orika/test/inheritance/UsedMappersTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/inheritance/UsedMappersTestCase.java
@@ -19,12 +19,11 @@
 package ma.glasnost.orika.test.inheritance;
 
 import org.junit.Assert;
+import org.junit.Test;
+
 import ma.glasnost.orika.MapperFacade;
 import ma.glasnost.orika.MapperFactory;
-import ma.glasnost.orika.metadata.ClassMapBuilder;
 import ma.glasnost.orika.test.MappingUtil;
-
-import org.junit.Test;
 
 public class UsedMappersTestCase {
     
@@ -89,12 +88,16 @@ public class UsedMappersTestCase {
     public void exclusionOnAbstractParent() throws Throwable {
     	
     	MapperFactory factory = MappingUtil.getMapperFactory();
-    	
-    	factory.classMap(Throwable.class, RuntimeException.class)
-    		.exclude("stackTrace")
-    		.favorExtension(true)
-    		.byDefault()
-    		.register();
+
+        factory.classMap(Throwable.class, RuntimeException.class)
+            .exclude("stackTrace")
+            .favorExtension(true)
+            .byDefault()
+            .register();
+        // TODO 17. Sep. 2015 : why is this registration required:
+        factory.classMap(UserUpdateException.class, UserRegistrationModelException.class)
+            .byDefault()
+            .register();
     	
     	UserUpdateException src = new UserUpdateException(true);
     	UserRegistrationModelException dest = factory.getMapperFacade().map(src, UserRegistrationModelException.class);
@@ -102,9 +105,10 @@ public class UsedMappersTestCase {
     	Assert.assertEquals(src.isEmailDuplicate(), dest.isEmailDuplicate());
     }
     
-    public static class UserUpdateException extends RuntimeException {
+    public static class UserUpdateException extends TestRuntimeException {
+        private static final long serialVersionUID = 1L;
 
-		private final boolean emailDuplicate;
+        private final boolean emailDuplicate;
 
 		public UserUpdateException(boolean emailDuplicate) {
 			this.emailDuplicate = emailDuplicate;
@@ -116,7 +120,8 @@ public class UsedMappersTestCase {
 
 	}
 
-	public static class UserRegistrationModelException extends Exception {
+    public static class UserRegistrationModelException extends TestException {
+        private static final long serialVersionUID = 1L;
 
 		private boolean emailDuplicate;
 
@@ -128,7 +133,35 @@ public class UsedMappersTestCase {
 			this.emailDuplicate = emailDuplicate;
 		}
 
-	}
+    }
+
+    public abstract static class TestRuntimeException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public StackTraceElement[] getStackTrace() {
+            throw new UnsupportedOperationException("getStackTrace should never be called.");
+        }
+
+        @Override
+        public void setStackTrace(StackTraceElement[] stackTrace) {
+            super.setStackTrace(stackTrace);
+        }
+    }
+
+    public abstract static class TestException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public StackTraceElement[] getStackTrace() {
+            throw new UnsupportedOperationException("getStackTrace should never be called.");
+        }
+
+        @Override
+        public void setStackTrace(StackTraceElement[] stackTrace) {
+            super.setStackTrace(stackTrace);
+        }
+    }
     
     public static abstract class A {
         private String name;

--- a/tests/src/main/java/ma/glasnost/orika/test/metadata/TypeFactoryTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/metadata/TypeFactoryTestCase.java
@@ -17,16 +17,26 @@
  */
 package ma.glasnost.orika.test.metadata;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import ma.glasnost.orika.metadata.Type;
 import ma.glasnost.orika.metadata.TypeFactory;
-
-import org.junit.Test;
 
 /**
  * @author matt.deboer@gmail.com
@@ -34,6 +44,9 @@ import org.junit.Test;
  */
 public class TypeFactoryTestCase {
     
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
     @Test
     public void createTypeFromClass() {
         Type<?> type = TypeFactory.valueOf("java.util.List");
@@ -73,7 +86,7 @@ public class TypeFactoryTestCase {
         Assert.assertEquals(File.class, type.getNestedType(0).getNestedType(1).getNestedType(0).getNestedType(1).getRawType());
         
     }
-    
+
     @Test(expected=IllegalArgumentException.class)
     public void createTypeFromMultipleNestedClass_invalidExpression() {
         TypeFactory.valueOf("List<Map<String,Set<Map<String,java.io.File>>>");
@@ -83,5 +96,84 @@ public class TypeFactoryTestCase {
     public void createTypeFromMultipleNestedClass_invalidType() {
         TypeFactory.valueOf("List<Map<String,Set<Map<String,java.io.FooBar>>>>");
     }
-    
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void createTypeWithMultibleBounds() {
+        Type<MyObjectWithMultibleBound> valueOf = TypeFactory.valueOf(MyObjectWithMultibleBound.class);
+        Assert.assertEquals("MyObjectWithMultibleBound<Set<String>>", valueOf.toString());
+
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void createTypeFromClassHirarchy() {
+        Type type = TypeFactory.valueOf(MyObject2.class);
+        Type<MyInterface> interfaceType = TypeFactory.valueOf(MyInterface.class);
+
+        TypeFactory.valueOf(interfaceType);
+        java.lang.reflect.Type firstArgType = type.findInterface(interfaceType).getActualTypeArguments()[0];
+        Type firstType = TypeFactory.valueOf(firstArgType);
+        Assert.assertEquals(String.class, firstType.getRawType());
+
+        java.lang.reflect.Type secondArgType = type.findInterface(interfaceType).getActualTypeArguments()[1];
+        Type secondType = TypeFactory.valueOf(secondArgType);
+        Assert.assertEquals(Collection.class, secondType.getRawType());
+
+    }
+
+    @Test
+    public void testRefineBoundsSuccess() throws Exception {
+        testRefineBoundsSuccess(Long.class, Long.class, Object.class);
+        testRefineBoundsSuccess(HashSet.class, Set.class, HashSet.class, Object.class);
+    }
+
+    @Test
+    public void testRefineBoundsFail() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage(containsString("Long")); // it can be "Long and String" or "String and Long"
+        thrown.expectMessage(containsString("String"));
+        thrown.expectMessage(containsString("are not comparable"));
+
+        testRefineBoundsSuccess(HashSet.class, String.class, Long.class);
+    }
+
+    @SuppressWarnings("rawtypes")
+    public void testRefineBoundsSuccess(Class<?> expetedClass, Class<?>... boundsClass) throws Exception {
+        Set<Type<?>> bounds = new HashSet<Type<?>>();
+        for (Class<?> clazz : boundsClass) {
+            bounds.add(TypeFactory.valueOf(clazz));
+        }
+        assertThat(refineBounds(bounds), is((Type) TypeFactory.valueOf(expetedClass)));
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static Type refineBounds(Set<Type<?>> bounds) throws Exception {
+        // call private TypeFactory.refineBounds() per reflection:
+        Class<TypeFactory> typeFactoryClass = TypeFactory.class;
+        Method refineMethod = typeFactoryClass.getDeclaredMethod("refineBounds", Set.class);
+        refineMethod.setAccessible(true);
+        try {
+            return (Type) refineMethod.invoke(null, bounds);
+        } catch (InvocationTargetException e) {
+            if (e.getTargetException() instanceof RuntimeException) {
+                throw (RuntimeException) e.getTargetException();
+            }
+            throw e;
+        }
+    }
+
+    public static class MyObject2 implements MyInterface<String, Collection<? super Long>> {
+        // test Class
+    }
+
+    @SuppressWarnings("unused")
+    public static interface MyInterface<A, B> {
+        // test Class
+    }
+
+    @SuppressWarnings("unused")
+    public static class MyObjectWithMultibleBound<T extends Object & Collection<String> & Set<String>> {
+        // test Class
+    }
 }

--- a/tests/src/main/java/ma/glasnost/orika/test/perf/ClassLoaderLeakageTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/perf/ClassLoaderLeakageTestCase.java
@@ -337,7 +337,6 @@ public class ClassLoaderLeakageTestCase {
 	private synchronized void forceClearSoftAndWeakReferences() {
 
 		SoftReference<Object> checkReference = new SoftReference<Object>(new Object());
-		Assert.assertNotNull(checkReference.get());
 		List<byte[]> byteBucket = new ArrayList<byte[]>();
 		try {
 			for (int i = 0; i < Integer.MAX_VALUE; ++i) {

--- a/tests/src/main/java/ma/glasnost/orika/test/perf/MultiThreadedTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/perf/MultiThreadedTestCase.java
@@ -33,7 +33,6 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Assert;
 import ma.glasnost.orika.MapperFacade;
 import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
@@ -52,6 +51,7 @@ import ma.glasnost.orika.test.common.types.TestCaseClasses.LibraryDTO;
 import ma.glasnost.orika.test.common.types.TestCaseClasses.LibraryImpl;
 
 import org.apache.commons.lang.time.DateUtils;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -374,7 +374,6 @@ public class MultiThreadedTestCase {
     	if (IS_IBM_JDK) {
     		synchronized(this) {
 	    		SoftReference<Object> checkReference = new SoftReference<Object>(new Object());
-		        Assert.assertNotNull(checkReference.get());
 		        List<byte[]> byteBucket = new ArrayList<byte[]>();
 		        try {
 		            for (int i = 0; i < Integer.MAX_VALUE; ++i) {
@@ -395,7 +394,6 @@ public class MultiThreadedTestCase {
     		}
     	} else {
 	        SoftReference<Object> checkReference = new SoftReference<Object>(new Object());
-	        Assert.assertNotNull(checkReference.get());
 	        List<byte[]> byteBucket = new ArrayList<byte[]>();
 	        try {
 	            for (int i = 0; i < Integer.MAX_VALUE; ++i) {


### PR DESCRIPTION
added JDK6 to travis-ci and fix a UnitTest which failed in JDK6.

The UnitTest didn't validate that the exclude "really" worked.
In openJDK6 it didn't worked because the Stacktrace could not be copied from one instance to another..
But the exclution did also not work in other JDKs. But the Test didn't fail because the StackTrace could be copied in other JDKs without error.

I added a TODO into the Test. Maybe there is a real problem!?

BTW: do you know why GitHub cannot create a nice Diff?

with friendly regards,
Harald

ps.: at next I will look at the ConcurrentModificationException that occurs sometimes in TypeFactory.refineBounds(311)


