### PR TITLE
Add Sub-Module for special jdk8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: java
 jdk:
   - openjdk6

--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,15 @@
 
 	<profiles>
 		<profile>
+			<id>include-jdk8-test</id>
+			<activation>
+				<jdk>1.8</jdk>
+			</activation>
+			<modules>
+				<module>tests-jdk8</module>
+			</modules>
+		</profile>
+		<profile>
 			<id>docs</id>
 			<build>
 				<plugins>

--- a/tests-jdk8/.gitignore
+++ b/tests-jdk8/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/.settings/
+/.classpath
+/.project

--- a/tests-jdk8/pom.xml
+++ b/tests-jdk8/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>orika-parent</artifactId>
+		<groupId>ma.glasnost.orika</groupId>
+		<version>1.5.0-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>orika-tests-jdk8</artifactId>
+	<name>Orika - tests for JDK8</name>
+
+	<properties>
+		<javassist.version>3.20.0-GA</javassist.version>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+	</properties>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>ma.glasnost.orika</groupId>
+			<artifactId>orika-core</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>ma.glasnost.orika</groupId>
+			<artifactId>orika-eclipse-tools</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>compile</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-simple</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-library</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-core</artifactId>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-lang</groupId>
+			<artifactId>commons-lang</artifactId>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-collections</groupId>
+			<artifactId>commons-collections</artifactId>
+			<scope>compile</scope>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.3</version>
+				<configuration>
+					<source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.18.1</version>
+				<configuration>
+					<argLine>-Xmx512m</argLine>
+					<systemPropertyVariables>
+						<!-- Prevent accidental usage of EclipseJdt compiler strategy (outside of the EclipseJdt-specific tests -->
+						<ma.glasnost.orika.test.MappingUtil.noDebug>true</ma.glasnost.orika.test.MappingUtil.noDebug>
+					</systemPropertyVariables>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/tests-jdk8/src/test/java/ma/glasnost/orika/test/jdk8/InterfaceDefaultMethodTest.java
+++ b/tests-jdk8/src/test/java/ma/glasnost/orika/test/jdk8/InterfaceDefaultMethodTest.java
@@ -1,0 +1,49 @@
+package ma.glasnost.orika.test.jdk8;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.junit.Test;
+
+import ma.glasnost.orika.impl.DefaultMapperFactory;
+
+public class InterfaceDefaultMethodTest {
+    
+    @Test
+    public void defaultInterfaceImplementationsTest() {
+        DefaultMapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        
+        mapperFactory.classMap(A.class, B.class).byDefault().register();
+        
+        A a = new A();
+        B b = new B();
+        
+        mapperFactory.getMapperFacade().map(a, b);
+        assertThat(b, notNullValue());
+        assertThat(b.getId(), is("test"));
+    }
+    
+    public interface BaseA {
+        
+        default String getId() {
+            return "test";
+        }
+    }
+    
+    public class A implements BaseA {
+        // inherited default methods from Interface
+    }
+    
+    public class B {
+        String id;
+        
+        public String getId() {
+            return id;
+        }
+        
+        public void setId(String id) {
+            this.id = id;
+        }
+    }
+}


### PR DESCRIPTION
Hi,
I created an additional sub-module for special JDK-8 Tests for analysing the question:
https://groups.google.com/forum/#!topic/orika-discuss/0l1_LPNW-6A

This Sub-modules runs on Travis-ci only for the JDK-8 build.

I'm not sure if you like it. At the moment there is only one test in it..
Please let me know.
