### PR TITLE
Do not loose Map instance when mapping MultiOccurenceVariable to a Map

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/impl/generator/MultiOccurrenceVariableRef.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/MultiOccurrenceVariableRef.java
@@ -156,18 +156,32 @@ public class MultiOccurrenceVariableRef extends VariableRef {
      * @return
      */
     public String addAll(VariableRef value) {
+        String assignment = addAllByAssign(value);
+        return assignment != null ? assignment : addAllButNoAssign(value);
+    }
+
+    private String addAllByAssign(VariableRef value) {
         if (isArray() && value.isCollection()) {
             if (type().getComponentType().isPrimitive()) {
                 return assign("%sArray(%s)", type().getComponentType().getCanonicalName(), value);
             } else {
                 return assign("listToArray(%s, %s.class)", value, type().getCanonicalName());
             }
-        } else if (isMap() && value.isList()) {
-            if (isAssignable()) {
-                return assign("listToMap(%s, java.util.LinkedHashMap.class)", value);
-            } else {
-                return String.format("listToMap(%s, %s)", value, this);
-            }
+        } else if (isMap() && value.isList() && isAssignable()) {
+            return assign("listToMap(%s, java.util.LinkedHashMap.class)", value);
+        }
+        return null;
+    }
+
+    /**
+     * A convenience function which adds all of one multi-occurence type to another variable, but without any assignment
+     *
+     * @param value
+     * @return
+     */
+    public String addAllButNoAssign(VariableRef value) {
+        if (isMap() && value.isList()) {
+            return String.format("listToMap(%s, %s)", value, this);
         } else if (isCollection() && value.isArray()) {
             if (value.type().getComponentType().isPrimitive()) {
                 return getter() + ".addAll(asList(" + value + "))";

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/specification/MultiOccurrenceToMultiOccurrence.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/specification/MultiOccurrenceToMultiOccurrence.java
@@ -287,9 +287,12 @@ public class MultiOccurrenceToMultiOccurrence implements AggregateSpecification 
          */
         for (Node destRef : destNodes) {
             if (destRef.isRoot() && !destRef.isLeaf()) {
-                if (destRef.multiOccurrenceVar.isArray() || destRef.multiOccurrenceVar.isMap()) {
+                if (destRef.multiOccurrenceVar.isArray()) {
                     /*
                      * We use a List as the temporary collector element for Arrays and Maps
+                     * The collector element for Maps can be handled as all other cases here,
+                     * because a reassign to the local destRef variable doesn't makes sense.
+                     * @see Github issues #82 and #87
                      */
                     append(out,
                             format("if (%s && %s) {",destRef.newDestination.notNull(), destRef.newDestination.notEmpty()),
@@ -303,7 +306,7 @@ public class MultiOccurrenceToMultiOccurrence implements AggregateSpecification 
                             "} else {\n",
                             destRef.multiOccurrenceVar + ".clear()",
                             "}\n",
-                            destRef.multiOccurrenceVar.addAll(destRef.newDestination),
+                            destRef.multiOccurrenceVar.addAllButNoAssign(destRef.newDestination),
                             "}\n");
                 }
             }

--- a/tests/src/main/java/ma/glasnost/orika/test/community/PullRequest88TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/PullRequest88TestCase.java
@@ -1,0 +1,62 @@
+package ma.glasnost.orika.test.community;
+
+import ma.glasnost.orika.MapperFacade;
+import ma.glasnost.orika.MapperFactory;
+import ma.glasnost.orika.metadata.Type;
+import ma.glasnost.orika.metadata.TypeBuilder;
+import ma.glasnost.orika.test.MappingUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+
+public class PullRequest88TestCase {
+    public static final Type<Set<A>> SET = new TypeBuilder<Set<A>>() {}.build();
+    public static final Type<Map<String, String>> MAP = new TypeBuilder<Map<String, String>>() {}.build();
+
+    private MapperFacade mapper;
+
+    @Before
+    public void setUp() {
+        MapperFactory mapperFactory = MappingUtil.getMapperFactory();
+        mapperFactory.classMap(SET, MAP)
+                .field("{name}", "{key}")
+                .field("{name}", "{value}")
+                .register();
+
+        mapper = mapperFactory.getMapperFacade();
+    }
+
+    @Test
+    public void testSetToMap() throws Exception {
+        Set<A> set = new HashSet<A>(asList(new A("a"), new A("b")));
+        Map<String, String> map = mapper.map(set, SET, MAP);
+        assertThat(map.keySet(), is(not(empty())));
+        assertThat(map, hasEntry("a", "a"));
+        assertThat(map, hasEntry("b", "b"));
+    }
+
+    public static class A {
+        private String name;
+
+        public A(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}
+


### PR DESCRIPTION
This pull request fixes #82.

It makes the generated mapper preserve the values of a target map, when mapping from a MultiOccurenceVariable to a MultiOccurenceVariable.