### PR TITLE
Fix for NullPointerException in CloneableConverter

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/converter/builtin/CloneableConverter.java
+++ b/core/src/main/java/ma/glasnost/orika/converter/builtin/CloneableConverter.java
@@ -109,6 +109,10 @@ public class CloneableConverter extends CustomConverter<Object, Object> {
     }
     
     public Object convert(Object source, Type<? extends Object> destinationType, MappingContext context) {
+    	if (source == null) {
+    		return null;
+    	}
+    	
         try {
             Method clone;
             if (cloneMethod != null) {

--- a/tests/src/main/java/ma/glasnost/orika/test/converter/CloneableConverterTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/converter/CloneableConverterTestCase.java
@@ -86,20 +86,30 @@ public class CloneableConverterTestCase {
         	.byDefault().register();
         MapperFacade facade = factory.getMapperFacade();
         
-        Date date = new Date(System.currentTimeMillis() + 100000);
-        SourceDateHolder sourceObject = new SourceDateHolder(date);
+        Date date1 = new Date(System.currentTimeMillis() + 100001);        
+        Date date2 = new Date(System.currentTimeMillis() + 100002);        
         ArrayOfDates arrayOfDate = new ArrayOfDates();
-        arrayOfDate.getDateHolder().add(sourceObject);
-        arrayOfDate.getDateHolder().add(new SourceDateHolder(null));
+        arrayOfDate.getDateHolder().add(new SourceDateHolder(date1));
+        arrayOfDate.getDateHolder().add(new SourceDateHolder(date2));
                 
         ComplexSource complexSource = new ComplexSource(arrayOfDate);
         ComplexDest complexDest = facade.map(complexSource, ComplexDest.class);
                 
         Assert.assertEquals(complexSource.getSomeDate().getDateHolder().size(), complexDest.getMeaningfulDate().size());
-        Assert.assertEquals(complexSource.getSomeDate().getDateHolder().get(0).getDate(), complexDest.getMeaningfulDate().get(0).getDate());        
-        Assert.assertNotSame(complexSource.getSomeDate().getDateHolder().get(0).getDate(), complexDest.getMeaningfulDate().get(0).getDate());
         
-        Assert.assertEquals(complexSource.getSomeDate().getDateHolder().get(1).getDate(), complexDest.getMeaningfulDate().get(1).getDate());
+        Assert.assertEquals(date1, complexDest.getMeaningfulDate().get(0).getDate());        
+        Assert.assertNotSame(date1, complexDest.getMeaningfulDate().get(0).getDate());
+        
+        Assert.assertEquals(date2, complexDest.getMeaningfulDate().get(1).getDate());        
+        Assert.assertNotSame(date2, complexDest.getMeaningfulDate().get(1).getDate());
+        
+        complexSource.getSomeDate().getDateHolder().add(new SourceDateHolder(null));
+        
+        // use cached clone method here without checking if source is null causes a NullPointerException 
+        complexDest = facade.map(complexSource, ComplexDest.class);
+        Assert.assertEquals(complexSource.getSomeDate().getDateHolder().size(), complexDest.getMeaningfulDate().size());
+        
+        Assert.assertNull(complexDest.getMeaningfulDate().get(2).getDate());
     }
     
     


### PR DESCRIPTION
Hi,

I'm using Orika to map JAXWS generated code to JAXRS generated a code. I found an issue with the CloneableConverter that causes a NullPointerException if the source object is null. Strangely enough, the issue only seems to happen when using a somewhat object complex structure.

I added a unit test to CloneableConverterTestCase to demonstrate the issue, which was trivial to fix.

