### PR TITLE
update paranamer to version 2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 		<wagon-svn.version>1.8</wagon-svn.version>
 		<h2.version>1.3.154</h2.version>
 		<slf4j.version>1.6.6</slf4j.version>
-		<paranamer.version>2.7</paranamer.version>
+		<paranamer.version>2.8</paranamer.version>
 		<logback.version>1.0.6</logback.version>
 	</properties>
 


### PR DESCRIPTION
Fix for  https://github.com/orika-mapper/orika/issues/60 Updated paranamer version has fix for lambda expressions