### PR TITLE
Fix for issue#134

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/impl/DefaultCodeGenerationStrategy.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/DefaultCodeGenerationStrategy.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.impl.generator.AggregateSpecification;
+import ma.glasnost.orika.impl.generator.BaseSpecification;
 import ma.glasnost.orika.impl.generator.CodeGenerationStrategy;
 import ma.glasnost.orika.impl.generator.Specification;
 import ma.glasnost.orika.impl.generator.specification.AnyTypeToString;
@@ -108,7 +109,7 @@ public class DefaultCodeGenerationStrategy implements CodeGenerationStrategy {
         addSpec(this.specifications, spec, relativePosition, relativeSpec);
     }
     
-    protected static <T> void addSpec(List<T> specifications, T spec, Position relativePosition, Class<?> relativeSpec) {
+    protected static <T extends BaseSpecification> void addSpec(List<T> specifications, T spec, Position relativePosition, Class<? extends BaseSpecification> relativeSpec) {
         
         if (relativePosition == null || relativePosition == Position.LAST) {
             specifications.add(spec);

--- a/core/src/main/java/ma/glasnost/orika/impl/DefaultCodeGenerationStrategy.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/DefaultCodeGenerationStrategy.java
@@ -104,11 +104,11 @@ public class DefaultCodeGenerationStrategy implements CodeGenerationStrategy {
      * ma.glasnost.orika.impl.generator.CodeGenerationStrategy.Position,
      * ma.glasnost.orika.impl.generator.Specification)
      */
-    public void addSpecification(Specification spec, Position relativePosition, Class<Specification> relativeSpec) {
+    public void addSpecification(Specification spec, Position relativePosition, Class<? extends Specification> relativeSpec) {
         addSpec(this.specifications, spec, relativePosition, relativeSpec);
     }
     
-    protected static <T> void addSpec(List<T> specifications, T spec, Position relativePosition, Class<T> relativeSpec) {
+    protected static <T> void addSpec(List<T> specifications, T spec, Position relativePosition, Class<?> relativeSpec) {
         
         if (relativePosition == null || relativePosition == Position.LAST) {
             specifications.add(spec);

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/AggregateSpecification.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/AggregateSpecification.java
@@ -30,19 +30,9 @@ import ma.glasnost.orika.metadata.FieldMap;
  * @author mattdeboer
  *
  */
-public interface AggregateSpecification {
+public interface AggregateSpecification extends BaseSpecification {
     
     void setMapperFactory(MapperFactory mapperFactory);
-    
-    /**
-     * Tests whether this Specification applies to the specified MappedTypePair
-     * @param fieldMap 
-     * 
-     * @param typePair
-     * @return true if this specification applies to the given MappedTypePair
-     */
-    boolean appliesTo(FieldMap fieldMap);
-    
     
     /**
      * @param fieldMappings

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/BaseSpecification.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/BaseSpecification.java
@@ -1,0 +1,19 @@
+package ma.glasnost.orika.impl.generator;
+
+import ma.glasnost.orika.metadata.FieldMap;
+
+/**
+ * Base Specification that contains the common methods for all Specifications.
+ * See {@link Specification} and {@link AggregateSpecification}
+ *
+ * @author Kalyan Ayyagari kalyan01
+ */
+public interface BaseSpecification {
+    /**
+     * Tests whether this Specification applies to the specified MappedTypePair
+     * @param fieldMap
+     *
+     * @return true if this specification applies to the given MappedTypePair
+     */
+    boolean appliesTo(FieldMap fieldMap);
+}

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/CodeGenerationStrategy.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/CodeGenerationStrategy.java
@@ -58,7 +58,7 @@ public interface CodeGenerationStrategy {
      * @param relativePosition the relative position
      * @param relativeSpec the other relative spec (for Positions BEFORE, AFTER, or IN_PLACE_OF)
      */
-    public void addSpecification(Specification spec, Position relativePosition, Class<Specification> relativeSpec);
+    public void addSpecification(Specification spec, Position relativePosition, Class<? extends Specification> relativeSpec);
     
     /**
      * @return the defined specifications 

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/Specification.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/Specification.java
@@ -28,19 +28,9 @@ import ma.glasnost.orika.metadata.FieldMap;
  * @author mattdeboer
  *
  */
-public interface Specification {
+public interface Specification extends BaseSpecification {
     
     void setMapperFactory(MapperFactory mapperFactory);
-    
-    /**
-     * Tests whether this Specification applies to the specified MappedTypePair
-     * @param fieldMap 
-     * 
-     * @param typePair
-     * @return true if this specification applies to the given MappedTypePair
-     */
-    boolean appliesTo(FieldMap fieldMap);
-    
     
     /**
      * Generates code for a boolean equality test between the two variable types,
@@ -48,8 +38,7 @@ public interface Specification {
      * 
      * @param source
      * @param destination
-     * @param inverseProperty 
-     * @param code 
+     * @param code
      * @return the code snippet which represents a true|false statement describing
      * whether the two types should be considered 'equal'
      */
@@ -62,8 +51,7 @@ public interface Specification {
      * @param fieldMap the fieldMap for which source code should be generated
      * @param source a convenience wrapper around the source field which can be used facilitate code generation
      * @param destination a convenience wrapper around the destination field which can be used facilitate code generation
-     * @param inverseProperty 
-     * @param code 
+     * @param code
      * @return the code snippet which represents mapping from the source to destination
      * property
      */

--- a/tests/src/main/java/ma/glasnost/orika/test/generator/CodeGenerationAddSpecificationCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/generator/CodeGenerationAddSpecificationCase.java
@@ -1,0 +1,61 @@
+package ma.glasnost.orika.test.generator;
+
+import ma.glasnost.orika.impl.DefaultMapperFactory;
+import ma.glasnost.orika.impl.generator.CodeGenerationStrategy;
+import ma.glasnost.orika.impl.generator.SourceCodeContext;
+import ma.glasnost.orika.impl.generator.Specification;
+import ma.glasnost.orika.impl.generator.VariableRef;
+import ma.glasnost.orika.impl.generator.specification.Convert;
+import ma.glasnost.orika.metadata.FieldMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+/*
+ * Orika - simpler, better and faster Java bean mapping
+ *
+ * Copyright (C) 2011-2013 Orika authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class CodeGenerationAddSpecificationCase {
+
+    @Test
+    public void testAddSpecification() {
+        Specification testSpec = new TestSpecification();
+        DefaultMapperFactory.Builder builder = new DefaultMapperFactory.Builder();
+        CodeGenerationStrategy codeGenerationStrategy = builder.getCodeGenerationStrategy();
+        codeGenerationStrategy.addSpecification(testSpec, CodeGenerationStrategy.Position.IN_PLACE_OF, Convert.class);
+        DefaultMapperFactory mapperFactory= builder.build();
+
+        Assert.assertTrue(codeGenerationStrategy.getSpecifications().contains(testSpec));
+    }
+
+    private class TestSpecification extends Convert {
+        @Override
+        public boolean appliesTo(FieldMap fieldMap) {
+            return super.appliesTo(fieldMap);
+        }
+
+        @Override
+        public String generateEqualityTestCode(FieldMap fieldMap, VariableRef source, VariableRef destination,
+                                               SourceCodeContext code) {
+            return super.generateEqualityTestCode(fieldMap, source, destination, code);
+        }
+
+        @Override
+        public String generateMappingCode(FieldMap fieldMap, VariableRef source, VariableRef destination,
+                                          SourceCodeContext code) {
+            return super.generateMappingCode(fieldMap, source, destination, code);
+        }
+    }
+}


### PR DESCRIPTION
Please see the issue for description: https://github.com/orika-mapper/orika/issues/134

I had to do some refactoring (create a base interface for Specification and AggregateSpecification) to make DefaultCodeGenerationStrategy.addSpec() work with the change to CodeGenerationStrategy.

