### PR TITLE
Catch case where constructorArguments are not set

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/impl/generator/ObjectFactoryGenerator.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/ObjectFactoryGenerator.java
@@ -168,7 +168,7 @@ public class ObjectFactoryGenerator {
                 List<FieldMap> properties = constructorMapping.getMappedFields();
                 Type<?>[] constructorArguments = constructorMapping.getParameterTypes();
                 
-                if (properties.size() != constructorArguments.length) {
+                if (constructorArguments == null || properties.size() != constructorArguments.length) {
                     throw new MappingException("While attempting to generate ObjectFactory using constructor '" + constructor
                             + "', an automatic mapping of the source type ('" + sourceType
                             + "') to this constructor call could not be determined. Please "


### PR DESCRIPTION
I am hoping such a minor fix does not need a full test.  I will write one up if needed.

When attempting to automap incompatible classes, this line generates a null pointer exception instead of the much more helpful mapping exception that is intended.

ParameterTypes are never set in [SimpleConstructorResolverFactory](https://github.com/orika-mapper/orika/blob/master/core/src/main/java/ma/glasnost/orika/constructor/SimpleConstructorResolverStrategy.java#L138) when targetParameters and parameterNames (line 128) do not match up.
As a result, this exception, I assume is intended, for this situation is never thrown.