### PR TITLE
Remove duplicated call to build() method that causes deadlock as poin…

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/impl/DefaultMapperFactory.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/DefaultMapperFactory.java
@@ -1461,9 +1461,6 @@ public class DefaultMapperFactory implements MapperFactory, Reportable {
      * .Type, ma.glasnost.orika.metadata.Type, boolean)
      */
     public <S, D> BoundMapperFacade<S, D> getMapperFacade(Type<S> sourceType, Type<D> destinationType, boolean containsCycles) {
-        if (!isBuilt && !isBuilding) {
-            build();
-        }
         getMapperFacade();
         MappingContextFactory ctxFactory = containsCycles ? contextFactory : nonCyclicContextFactory;
         return new DefaultBoundMapperFacade<S, D>(this, ctxFactory, sourceType, destinationType);


### PR DESCRIPTION
…ted in issue #56 

Now the method build() is called only by getMapperFacade()