### PR TITLE
Enhance RegexPropertyResolver to allow regex expressions with more than one capture group

### DIFF
--- a/tests/src/main/java/ma/glasnost/orika/test/property/RegexPropertyResolverTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/property/RegexPropertyResolverTestCase.java
@@ -17,7 +17,6 @@
  */
 package ma.glasnost.orika.test.property;
 
-import org.junit.Assert;
 import ma.glasnost.orika.MapperFacade;
 import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
@@ -25,40 +24,41 @@ import ma.glasnost.orika.property.RegexPropertyResolver;
 import ma.glasnost.orika.test.property.TestCaseClasses.A;
 import ma.glasnost.orika.test.property.TestCaseClasses.Address;
 import ma.glasnost.orika.test.property.TestCaseClasses.B;
+import ma.glasnost.orika.test.property.TestCaseClasses.C;
+import ma.glasnost.orika.test.property.TestCaseClasses.D;
 import ma.glasnost.orika.test.property.TestCaseClasses.Name;
-
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
  * @author matt.deboer@gmail.com
- *
  */
 public class RegexPropertyResolverTestCase {
-    
+
     @Test
     public void testRegexResolution() {
-        
-        MapperFactory factory = 
+
+        MapperFactory factory =
                 new DefaultMapperFactory.Builder()
-                    .propertyResolverStrategy(
-                            new RegexPropertyResolver(
-                                    "readThe([\\w]+)ForThisBean",
-                                    "assignThe([\\w]+)",
-                                    true, true))
-                    .build();
+                        .propertyResolverStrategy(
+                                new RegexPropertyResolver(
+                                        "readThe([\\w]+)ForThisBean",
+                                        "assignThe([\\w]+)",
+                                        true, true))
+                        .build();
         factory.registerClassMap(
                 factory.classMap(A.class, B.class)
-                    .field("name.firstName", "givenName")
-                    .field("name.lastName", "sirName")
-                    .field("address.city", "city")
-                    .field("address.street", "street")
-                    .field("address.postalCode", "postalCode")
-                    .field("address.country", "country")
-                );
-        
-        
+                        .field("name.firstName", "givenName")
+                        .field("name.lastName", "sirName")
+                        .field("address.city", "city")
+                        .field("address.street", "street")
+                        .field("address.postalCode", "postalCode")
+                        .field("address.country", "country")
+        );
+
+
         MapperFacade mapper = factory.getMapperFacade();
-        
+
         A a = new A();
         Name name = new Name();
         name.setFirstName("Albert");
@@ -70,15 +70,49 @@ public class RegexPropertyResolverTestCase {
         address.postalCode = "A1234FG";
         address.street = "1234 Easy St.";
         a.setAddress(address);
-        
-        
+
+
         B b = mapper.map(a, B.class);
-        
+
         Assert.assertNotNull(b);
-        
+
         A mapBack = mapper.map(b, A.class);
-        
+
         Assert.assertEquals(a, mapBack);
-        
+
+    }
+
+    @Test
+    public void testRegexResolutionWithSpecifiedCaptureGroupIndex() throws Exception {
+        MapperFactory factory =
+                new DefaultMapperFactory.Builder()
+                        .propertyResolverStrategy(
+                                new RegexPropertyResolver(
+                                        "(get)(\\w+)", //arbitrarily make the getter regex have two capture groups
+                                        "(set|with)(\\w+)", //C.Builder has withXXX methods and D.Builder has setXXX methods
+                                        true, true, 2, 2)) //our write method regex has two capture groups, index=2 captures the property name
+                        .build();
+
+        factory.registerClassMap(
+                factory.classMap(TestCaseClasses.C.class, D.Builder.class)
+                        .byDefault());
+
+        factory.registerClassMap(
+                factory.classMap(TestCaseClasses.D.class, C.Builder.class)
+                        .byDefault());
+
+
+        MapperFacade mapper = factory.getMapperFacade();
+
+        C c = new C.Builder()
+                .withFoo("hello")
+                .withBar(33)
+                .build();
+
+        D d = mapper.map(c, D.Builder.class).build();
+
+        C c1 = mapper.map(d, C.Builder.class).build();
+
+        Assert.assertEquals(c, c1);
     }
 }

--- a/tests/src/main/java/ma/glasnost/orika/test/property/TestCaseClasses.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/property/TestCaseClasses.java
@@ -313,6 +313,130 @@ public interface TestCaseClasses {
         public String postalCode;
         public String country;
     }
+
+    public static class C {
+		private final String foo;
+		private final int bar;
+
+
+		private C(String foo, int bar) {
+			this.foo = foo;
+			this.bar = bar;
+		}
+
+		public String getFoo() {
+			return foo;
+		}
+
+		public int getBar() {
+			return bar;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+
+			C c = (C) o;
+
+			if (bar != c.bar) return false;
+			return foo != null ? foo.equals(c.foo) : c.foo == null;
+
+		}
+
+		@Override
+		public int hashCode() {
+			int result = foo != null ? foo.hashCode() : 0;
+			result = 31 * result + bar;
+			return result;
+		}
+
+		public static class Builder {
+			private String foo;
+			private int bar;
+
+			public Builder() {
+			}
+
+			public Builder withFoo(String foo) {
+				this.foo = foo;
+				return this;
+			}
+
+			public Builder withBar(int bar) {
+				this.bar = bar;
+				return this;
+			}
+
+
+			public C build() {
+				return new C(foo, bar);
+			}
+		}
+	}
+
+	public static class D {
+		private final String foo;
+		private final int bar;
+
+
+		private D(String foo, int bar) {
+			this.foo = foo;
+			this.bar = bar;
+		}
+
+		public String getFoo() {
+			return foo;
+		}
+
+		public int getBar() {
+			return bar;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+
+			D d = (D) o;
+
+			if (bar != d.bar) return false;
+			return foo != null ? foo.equals(d.foo) : d.foo == null;
+
+		}
+
+		@Override
+		public int hashCode() {
+			int result = foo != null ? foo.hashCode() : 0;
+			result = 31 * result + bar;
+			return result;
+		}
+
+		public static class Builder {
+			private String foo;
+			private int bar;
+
+			public Builder() {
+			}
+
+			public Builder setFoo(String foo) {
+				this.foo = foo;
+				return this;
+			}
+
+			public Builder setBar(int bar) {
+				this.bar = bar;
+				return this;
+			}
+
+
+			public D build() {
+				return new D(foo, bar);
+			}
+		}
+	}
+
+
     
     public static class Name {
         private String firstName;


### PR DESCRIPTION
Currently you cannot use a regex that has more than one capture group
because the RegexPropertyResolver assumes group(1) is the capture group
that will specify the property name.

In my code base I have the following use case:

1.  Some classes in the code base are immutable and you construct them
using a Builder class.
2. Some of the builder classes use a withXXX convention
3. Some of the builder classes use a setXXX convention
4. I needed a write method regex of “(with|set)(\\w+)” which broke when
the RegexPropertyResolver expected the group containing the property
name to have be index 1.

This change should be backwards compatible.