### PR TITLE
Improve TestCases and Java-8 DateTime Api support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-Orika ! [![Build Status](https://secure.travis-ci.org/orika-mapper/orika.png)](http://travis-ci.org/orika-mapper/orika)
+[![Build Status](https://secure.travis-ci.org/orika-mapper/orika.png)](http://travis-ci.org/orika-mapper/orika)
+[![GitHub site](https://img.shields.io/badge/GitHub-site-blue.svg)](http://orika-mapper.github.com/orika-docs/)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/ma.glasnost.orika/orika-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/ma.glasnost.orika/orika-core)
+[![Javadocs](http://www.javadoc.io/badge/ma.glasnost.orika/orika-core.svg)](http://www.javadoc.io/doc/ma.glasnost.orika/orika-core)
+[![License: Apache 2.0](https://img.shields.io/badge/license-Apache_2.0-brightgreen.svg)](https://github.com/orika-mapper/orika/blob/master/LICENSE)
+
+Orika !
 -----------------------------------------------------------------------
 
 **NEW** We are pleased to announce the release of Orika **1.5.0** ! _This version is available on Maven central repository_ 

--- a/tests-jdk8/src/test/java/ma/glasnost/orika/test/jdk8/InterfaceDefaultMethodTest.java
+++ b/tests-jdk8/src/test/java/ma/glasnost/orika/test/jdk8/InterfaceDefaultMethodTest.java
@@ -16,26 +16,23 @@ public class InterfaceDefaultMethodTest {
         
         mapperFactory.classMap(A.class, B.class).byDefault().register();
         
-        A a = new A();
-        B b = new B();
-        
-        mapperFactory.getMapperFacade().map(a, b);
+        B b = mapperFactory.getMapperFacade().map(new A(), B.class);
         assertThat(b, notNullValue());
         assertThat(b.getId(), is("test"));
     }
     
-    public interface BaseA {
+    public static interface BaseA {
         
         default String getId() {
             return "test";
         }
     }
     
-    public class A implements BaseA {
+    public static class A implements BaseA {
         // inherited default methods from Interface
     }
     
-    public class B {
+    public static class B {
         String id;
         
         public String getId() {

--- a/tests-jdk8/src/test/java/ma/glasnost/orika/test/jdk8/JavaDateApiTest.java
+++ b/tests-jdk8/src/test/java/ma/glasnost/orika/test/jdk8/JavaDateApiTest.java
@@ -1,0 +1,362 @@
+package ma.glasnost.orika.test.jdk8;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.io.File;
+import java.lang.reflect.Modifier;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalAmount;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import ma.glasnost.orika.CustomConverter;
+import ma.glasnost.orika.MappingContext;
+import ma.glasnost.orika.impl.DefaultMapperFactory;
+import ma.glasnost.orika.metadata.Type;
+import ma.glasnost.orika.metadata.TypeFactory;
+
+/**
+ * Support for JSR-310 (Date and Time).
+ * <p>
+ * 
+ * @see <a href="https://github.com/orika-mapper/orika/issues/170">https://github.com/orika-mapper/orika/issues/170</a>
+ * @see <a href="https://github.com/orika-mapper/orika/issues/96">https://github.com/orika-mapper/orika/issues/96</a>
+ */
+public class JavaDateApiTest {
+    
+    private static final org.slf4j.Logger LOG = org.slf4j.LoggerFactory.getLogger(JavaDateApiTest.class);
+    
+    @Test
+    public void testJavaDateApiMappings() {
+        DefaultMapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        
+        // prepare input
+        A a = new A();
+        a.setInstant(Instant.parse("2007-12-03T10:15:30.00Z"));
+        a.setDuration(Duration.parse("-PT6H3M"));
+        a.setLocalDate(LocalDate.parse("2007-12-03"));
+        a.setLocalTime(LocalTime.parse("10:15:30.00"));
+        a.setLocalDateTime(LocalDateTime.parse("2007-12-03T10:15:30.00"));
+        a.setZonedDateTime(ZonedDateTime.parse("2007-12-03T10:15:30.00+02:00[Europe/Vienna]"));
+        a.setDayOfWeek(DayOfWeek.MONDAY);
+        a.setMonth(Month.JULY);
+        a.setMonthDay(MonthDay.parse("--12-03"));
+        a.setOffsetDateTime(OffsetDateTime.parse("2007-12-03T10:15:30.00+02:00"));
+        a.setOffsetTime(OffsetTime.parse("10:15:30.00+02:00"));
+        a.setPeriod(Period.parse("-P1Y2M"));
+        a.setYear(Year.parse("2007"));
+        a.setYearMonth(YearMonth.parse("2007-12"));
+        a.setZoneOffset(ZoneOffset.of("+02:00"));
+        
+        // run Test:
+        A mappedA = mapperFactory.getMapperFacade().map(a, A.class);
+        
+        // validate result
+        assertThat(mappedA, notNullValue());
+        assertThat(mappedA.getInstant(), is(a.getInstant()));
+        assertThat(mappedA.getDuration(), is(a.getDuration()));
+        assertThat(mappedA.getLocalDate(), is(a.getLocalDate()));
+        assertThat(mappedA.getLocalTime(), is(a.getLocalTime()));
+        assertThat(mappedA.getLocalDateTime(), is(a.getLocalDateTime()));
+        assertThat(mappedA.getZonedDateTime(), is(a.getZonedDateTime()));
+        assertThat(mappedA.getDayOfWeek(), is(a.getDayOfWeek()));
+        assertThat(mappedA.getMonth(), is(a.getMonth()));
+        assertThat(mappedA.getMonthDay(), is(a.getMonthDay()));
+        assertThat(mappedA.getOffsetDateTime(), is(a.getOffsetDateTime()));
+        assertThat(mappedA.getOffsetTime(), is(a.getOffsetTime()));
+        assertThat(mappedA.getOffsetTime(), is(a.getOffsetTime()));
+        assertThat(mappedA.getPeriod(), is(a.getPeriod()));
+        assertThat(mappedA.getYear(), is(a.getYear()));
+        assertThat(mappedA.getYearMonth(), is(a.getYearMonth()));
+        assertThat(mappedA.getZoneOffset(), is(a.getZoneOffset()));
+        
+    }
+    
+    @Test
+    public void testJavaDateApiMappings_withCustomConverter_shouldOverwriteDefaultBehavior() {
+        DefaultMapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        mapperFactory.getConverterFactory().registerConverter(new CustomConverter<Instant, Instant>() {
+            public Instant convert(Instant source, Type<? extends Instant> destType, MappingContext mappingContext) {
+                if (source == null) {
+                    return null;
+                }
+                // TestCase: add 28 days during Mapping
+                return source.plus(Period.parse("P28D"));
+            }
+        });
+        
+        // prepare input
+        A a = new A();
+        a.setInstant(Instant.parse("2007-03-04T10:15:30.00Z"));
+        
+        // run Test:
+        A mappedA = mapperFactory.getMapperFacade().map(a, A.class);
+        
+        // validate result
+        assertThat(mappedA, notNullValue());
+        assertThat(mappedA.getInstant(), is(Instant.parse("2007-04-01T10:15:30.00Z")));
+        
+    }
+    
+    @Test
+    public void testJdk8Type_shouldBeImmutable() throws Exception {
+        // 1. find all SubClasses of TemporalAccessor, TemporalAmount
+        List<Class<?>> jdkClasses = new ArrayList<>();
+        jdkClasses.addAll(getJdkClasses("java.time", TemporalAccessor.class));
+        jdkClasses.addAll(getJdkClasses("java.time", TemporalAmount.class));
+        
+        // 2. filter Classes which should be immutable (TemporalAccessor and TemporalAmount should be implemented as immutable):
+        List<Class<?>> immutableJdkClasses = jdkClasses.stream()
+                .filter(this::immutableRequirements)
+                .collect(Collectors.toList());
+        
+        LOG.info("Found the following immutable classes: ");
+        immutableJdkClasses.forEach((type) -> LOG.info("\t {}", type.getName()));
+        
+        // validation: collect classes which are not identified as immutable (there should be none):
+        List<Class<?>> missingTypes = immutableJdkClasses.stream()
+                .filter((type) -> !TypeFactory.valueOf(type).isImmutable())
+                .collect(Collectors.toList());
+        
+        // throw Validation Exception if there are some classes.
+        // This can happen if the JDK introduces new Classes which most likely must be added to ma.glasnost.orika.metadata.Type.
+        if (!missingTypes.isEmpty()) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("Add the following immutable Types to ma.glasnost.orika.metadata.Type:\n");
+            missingTypes.forEach((type) -> {
+                sb.append(statement(type));
+                sb.append('\n');
+            });
+            LOG.warn(sb.toString());
+            Assert.fail(sb.toString());
+        }
+    }
+
+    private String statement(Class<?> subType) {
+        return "        addClassIfExists(tmpImmutableJdk8Types, \"" + subType.getName() + "\");";
+    }
+    
+    private boolean immutableRequirements(Class<?> subType) {
+        return Modifier.isFinal(subType.getModifiers()) // Immutable Classes are typical final
+                && Modifier.isPublic(subType.getModifiers()) // We are not interested in non-public classes
+                && !subType.isEnum(); // We don't need register Enums in ma.glasnost.orika.metadata.Type (they always are immutable)
+    }
+    
+    
+    @SuppressWarnings("unchecked")
+    private <T> List<Class<T>> getJdkClasses(String rootPackage, final Class<T> type) throws Exception {
+        
+        String rootPackagePath = rootPackage.replace('.', '/');
+        String path = type.getName().replace('.', '/') + ".class";
+        URL resource = ClassLoader.getSystemClassLoader().getResource(path);
+        if (resource == null) {
+            throw new RuntimeException("Unexpected problem: No resource for " + path);
+        }
+        String filePath = resource.getFile();
+        File jarFile = getJarFile(filePath);
+        
+        List<Class<T>> subTypes = new ArrayList<>();
+        
+        try (ZipFile zipFile = new ZipFile(jarFile)) {
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry zipEntry = entries.nextElement();
+                if (zipEntry.getName().startsWith(rootPackagePath)) {
+                    String className = zipEntry.getName();
+                    if (className.endsWith(".class")) {
+                        className = StringUtils.removeEnd(className, ".class");
+                        className = className.replace('/', '.');
+                        Class<?> clazz = Class.forName(className);
+                        if (type.isAssignableFrom(clazz)) {
+                            subTypes.add((Class<T>) clazz);
+                        }
+                    }
+                }
+            }
+        }
+        Collections.sort(subTypes, (type1, type2) -> type1.getName().compareTo(type2.getName()));
+        
+        return subTypes;
+    }
+    
+    private File getJarFile(String filePath) throws Exception {
+        String jarFilePath = filePath;
+        jarFilePath = URLDecoder.decode(jarFilePath, "UTF-8");
+        if (jarFilePath.startsWith("file:")) {
+            jarFilePath = StringUtils.substringAfter(jarFilePath, "file:");
+        }
+        if (jarFilePath.contains(".jar!")) {
+            jarFilePath = StringUtils.substringBefore(jarFilePath, ".jar!") + ".jar";
+        }
+        return new File(jarFilePath);
+    }
+    
+    public static class A {
+
+        private Instant instant;
+        private Duration duration;
+        private LocalDate localDate;
+        private LocalTime localTime;
+        private LocalDateTime localDateTime;
+        private ZonedDateTime zonedDateTime;
+        private DayOfWeek dayOfWeek;
+        private Month month;
+        private MonthDay monthDay;
+        private OffsetDateTime offsetDateTime;
+        private OffsetTime offsetTime;
+        private Period period;
+        private Year year;
+        private YearMonth yearMonth;
+        private ZoneOffset zoneOffset;
+        
+        public Instant getInstant() {
+            return instant;
+        }
+        
+        public void setInstant(Instant instant) {
+            this.instant = instant;
+        }
+        
+        public Duration getDuration() {
+            return duration;
+        }
+        
+        public void setDuration(Duration duration) {
+            this.duration = duration;
+        }
+        
+        public LocalDate getLocalDate() {
+            return localDate;
+        }
+        
+        public void setLocalDate(LocalDate localDate) {
+            this.localDate = localDate;
+        }
+        
+        public LocalTime getLocalTime() {
+            return localTime;
+        }
+        
+        public void setLocalTime(LocalTime localTime) {
+            this.localTime = localTime;
+        }
+        
+        public LocalDateTime getLocalDateTime() {
+            return localDateTime;
+        }
+        
+        public void setLocalDateTime(LocalDateTime localDateTime) {
+            this.localDateTime = localDateTime;
+        }
+        
+        public ZonedDateTime getZonedDateTime() {
+            return zonedDateTime;
+        }
+        
+        public void setZonedDateTime(ZonedDateTime zonedDateTime) {
+            this.zonedDateTime = zonedDateTime;
+        }
+        
+        public DayOfWeek getDayOfWeek() {
+            return dayOfWeek;
+        }
+        
+        public void setDayOfWeek(DayOfWeek dayOfWeek) {
+            this.dayOfWeek = dayOfWeek;
+        }
+        
+        public Month getMonth() {
+            return month;
+        }
+        
+        public void setMonth(Month month) {
+            this.month = month;
+        }
+        
+        public MonthDay getMonthDay() {
+            return monthDay;
+        }
+        
+        public void setMonthDay(MonthDay monthDay) {
+            this.monthDay = monthDay;
+        }
+        
+        public OffsetDateTime getOffsetDateTime() {
+            return offsetDateTime;
+        }
+        
+        public void setOffsetDateTime(OffsetDateTime offsetDateTime) {
+            this.offsetDateTime = offsetDateTime;
+        }
+        
+        public OffsetTime getOffsetTime() {
+            return offsetTime;
+        }
+        
+        public void setOffsetTime(OffsetTime offsetTime) {
+            this.offsetTime = offsetTime;
+        }
+        
+        public Period getPeriod() {
+            return period;
+        }
+        
+        public void setPeriod(Period period) {
+            this.period = period;
+        }
+        
+        public Year getYear() {
+            return year;
+        }
+        
+        public void setYear(Year year) {
+            this.year = year;
+        }
+        
+        public YearMonth getYearMonth() {
+            return yearMonth;
+        }
+        
+        public void setYearMonth(YearMonth yearMonth) {
+            this.yearMonth = yearMonth;
+        }
+        
+        public ZoneOffset getZoneOffset() {
+            return zoneOffset;
+        }
+        
+        public void setZoneOffset(ZoneOffset zoneOffset) {
+            this.zoneOffset = zoneOffset;
+        }
+
+    }
+    
+}

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue102TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue102TestCase.java
@@ -19,7 +19,6 @@
 package ma.glasnost.orika.test.community;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -30,6 +29,13 @@ import ma.glasnost.orika.impl.DefaultMapperFactory;
 
 import org.junit.Test;
 
+/**
+ * I'm not able to set map type using orika.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/102">https://code.google.com/archive/p/orika/</a>
+ * 
+ */
 public class Issue102TestCase {
     
     @Test

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue105TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue105TestCase.java
@@ -7,6 +7,13 @@ import ma.glasnost.orika.MapperFacade;
 import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
 
+/**
+ * Circular reference mapping with classes that extend an abstract class fail.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/143">https://code.google.com/archive/p/orika/</a>
+ * @see <a href="https://github.com/orika-mapper/orika/issues/105">https://github.com/orika-mapper/orika/issues</a>
+ */
 public class Issue105TestCase {
     @Test
     public void test() {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue109TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue109TestCase.java
@@ -28,6 +28,12 @@ import ma.glasnost.orika.test.MappingUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * Mapping for multi-occurrence elements doesn't trigger auto-generated mappings.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/109">https://code.google.com/archive/p/orika/</a>
+ */
 public class Issue109TestCase {
  
     public static class Element {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue112TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue112TestCase.java
@@ -30,11 +30,13 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
+ * Class cast exception to MapEntry.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/112">https://code.google.com/archive/p/orika/</a>
  * @author: ikrokhmalyov@griddynamics.com
  * @since: 7/1/13
  */
-
-
 public class Issue112TestCase {
     
     @Test

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue113TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue113TestCase.java
@@ -29,6 +29,10 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
+ * Cannot find a mapper when a child bean infers a generic type of its parent bean.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/113">https://code.google.com/archive/p/orika/</a>
  * @author Arnaud Jasselette
  * 
  */

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue114TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue114TestCase.java
@@ -7,6 +7,12 @@ import ma.glasnost.orika.impl.generator.EclipseJdtCompilerStrategy;
 
 import org.junit.Test;
 
+/**
+ * NPE on mapNulls in 1.4.3.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/114">https://code.google.com/archive/p/orika/</a>
+ */
 public class Issue114TestCase {
     
     

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue119TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue119TestCase.java
@@ -7,6 +7,12 @@ import ma.glasnost.orika.test.MappingUtil;
 
 import org.junit.Test;
 
+/**
+ * NPE on mapping nested field with collection.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/119">https://code.google.com/archive/p/orika/</a>
+ */
 public class Issue119TestCase {
     
     public static class Source {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue126TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue126TestCase.java
@@ -6,6 +6,12 @@ import ma.glasnost.orika.test.MappingUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * Exclude() does not work if the field is not present in both classes.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/126">https://code.google.com/archive/p/orika/</a>
+ */
 public class Issue126TestCase {
     
     public static class A {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue128TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue128TestCase.java
@@ -13,6 +13,12 @@ import ma.glasnost.orika.test.MappingUtil;
 
 import org.junit.Test;
 
+/**
+ * Mapping to Map&lt;String, List&lt;String&gt;&gt; only maps keys. Map&lt;String, ArrayList&lt;String&gt;&gt; works..
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/128">https://code.google.com/archive/p/orika/</a>
+ */
 public class Issue128TestCase {
     
     public static class A {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue129TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue129TestCase.java
@@ -5,6 +5,12 @@ import ma.glasnost.orika.converter.BidirectionalConverter;
 import ma.glasnost.orika.metadata.Type;
 import org.junit.Test;
 
+/**
+ * problem generic types when subclassing.
+ * <p>
+ * 
+ * @see <a href="https://github.com/orika-mapper/orika/issues/129">https://github.com/orika-mapper/orika/issues</a>
+ */
 public class Issue129TestCase {
     
     @Test

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue132TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue132TestCase.java
@@ -8,6 +8,12 @@ import ma.glasnost.orika.impl.DefaultMapperFactory;
 
 import org.junit.Test;
 
+/**
+ * Usage of .constructorA/B results in NullPointerException.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/132">https://code.google.com/archive/p/orika/</a>
+ */
 public class Issue132TestCase {
 
     @Test(expected=MappingException.class)

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue138TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue138TestCase.java
@@ -1,7 +1,6 @@
 package ma.glasnost.orika.test.community;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue138TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue138TestCase.java
@@ -10,6 +10,12 @@ import ma.glasnost.orika.test.MappingUtil;
 
 import org.junit.Test;
 
+/**
+ * Mapping of Lists are not functioning correctly with fieldAToB.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/138">https://code.google.com/archive/p/orika/</a>
+ */
 public class Issue138TestCase {
 
     @Test

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue140TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue140TestCase.java
@@ -13,6 +13,12 @@ import ma.glasnost.orika.metadata.TypeBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * mapAsMap breaks Object graphs.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/140">https://code.google.com/archive/p/orika/</a>
+ */
 public class Issue140TestCase {
 	public static class ParentA {
 		public ChildA child;

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue141TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue141TestCase.java
@@ -4,20 +4,20 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.Test;
+
 import ma.glasnost.orika.MapperFacade;
 import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
 import ma.glasnost.orika.impl.generator.EclipseJdtCompilerStrategy;
-import ma.glasnost.orika.impl.generator.VariableRef;
 import ma.glasnost.orika.metadata.CaseInsensitiveClassMapBuilder;
-import ma.glasnost.orika.metadata.NestedProperty;
-import ma.glasnost.orika.metadata.Property;
-import ma.glasnost.orika.property.IntrospectorPropertyResolver;
-import ma.glasnost.orika.property.PropertyResolver;
 
-import org.junit.Assert;
-import org.junit.Test;
-
+/**
+ * Compilation Error when referencing collection on class property.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/141">https://code.google.com/archive/p/orika/</a>
+ */
 public class Issue141TestCase {
 
 	public static class Clazz {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue148TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue148TestCase.java
@@ -30,6 +30,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
+ * Orika fails to map converter result to string (double cast).
+ * <p>
+ * I am trying to map an object to a string via a custom converter, with the converter returning null (e.g. because the source object is
+ * null)
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/148">https://code.google.com/archive/p/orika/</a>
  * @author dbb
  * @since 07.03.14
  */

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue14TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue14TestCase.java
@@ -31,6 +31,12 @@ import ma.glasnost.orika.test.MappingUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * Calendar as destination throwing exception.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/14">https://code.google.com/archive/p/orika/</a>
+ */
 public class Issue14TestCase {
     
     public static class Product {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue160TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue160TestCase.java
@@ -11,6 +11,12 @@ import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.MappingContext;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
 
+/**
+ * MapperFacade.map does not map into destination instance when context has already mapped the source Object.
+ * <p>
+ * 
+ * @see <a href="https://github.com/orika-mapper/orika/issues/160">https://github.com/orika-mapper/orika/issues</a>
+ */
 public class Issue160TestCase {
 
 	@Test

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue161TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue161TestCase.java
@@ -5,6 +5,12 @@ import ma.glasnost.orika.impl.DefaultMapperFactory;
 
 import org.junit.Test;
 
+/**
+ * Unable to map class with self-referencing generics and Comparable return type.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/161">https://code.google.com/archive/p/orika/</a>
+ */
 public class Issue161TestCase {
 
 	public static class Optional<T> {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue166TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue166TestCase.java
@@ -16,6 +16,12 @@ import ma.glasnost.orika.impl.DefaultMapperFactory;
 import ma.glasnost.orika.metadata.Type;
 import ma.glasnost.orika.metadata.TypeFactory;
 
+/**
+ * StackOverflowError exception when mapping enum.
+ * <p>
+ * 
+ * @see <a href="https://github.com/orika-mapper/orika/issues/166">https://github.com/orika-mapper/orika/issues</a>
+ */
 public class Issue166TestCase {
 
     @Test

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue166TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue166TestCase.java
@@ -25,7 +25,7 @@ public class Issue166TestCase {
         MapperFacade beanMapper = factory.getMapperFacade();
         
         SimpleBeanResource sbr = beanMapper.map(SimpleEnumBean.E1, SimpleBeanResource.class);
-        Assert.assertTrue(sbr.getName().equals(SimpleEnumBean.E1.getName()));
+        Assert.assertEquals(sbr.getName(), SimpleEnumBean.E1.getName());
     }
     
     @Test

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue167TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue167TestCase.java
@@ -19,10 +19,16 @@ import ma.glasnost.orika.metadata.TypeFactory;
 import ma.glasnost.orika.property.IntrospectorPropertyResolver;
 import ma.glasnost.orika.property.PropertyResolver;
 
+/**
+ * DefaultMapperFactory.classMap got in infinity loop when using F-bounded polymorphism.
+ * <p>
+ * 
+ * @see <a href="https://github.com/orika-mapper/orika/issues/167">https://github.com/orika-mapper/orika/issues</a>
+ */
 public class Issue167TestCase {
     
     @Test
-    public void testIssue166() throws Exception {
+    public void testIssue167() throws Exception {
         
         MapperFactory factory = new DefaultMapperFactory.Builder().build();
         

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue17TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue17TestCase.java
@@ -36,6 +36,13 @@ import ma.glasnost.orika.test.MappingUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * Mapping for Collection&lt;String&gt; --&gt; String[] is not working.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/17">https://code.google.com/archive/p/orika/</a>
+ *
+ */
 public class Issue17TestCase {
     
     public static class A {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue17TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue17TestCase.java
@@ -17,6 +17,9 @@
  */
 package ma.glasnost.orika.test.community;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -97,8 +100,7 @@ public class Issue17TestCase {
         Assert.assertNotNull(converted);
         Assert.assertNotNull(converted.getList());
         List<String> convertedList = Arrays.asList(converted.getList());
-        Assert.assertTrue(convertedList.containsAll(a.getList()));
-        Assert.assertTrue(a.getList().containsAll(convertedList));
+        assertThat(convertedList, contains("One", "Two", "Three"));
     }
     
     @Test

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue18TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue18TestCase.java
@@ -17,16 +17,18 @@
  */
 package ma.glasnost.orika.test.community;
 
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Assert;
+import org.junit.Test;
 
 import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
 import ma.glasnost.orika.metadata.ClassMapBuilder;
-
-import org.junit.Test;
 
 public class Issue18TestCase {
 
@@ -41,7 +43,7 @@ public class Issue18TestCase {
 		List<Object> listB = mapperFactory.getMapperFacade().mapAsList(listA, Object.class);
 		
 		Assert.assertNotNull(listB);
-		Assert.assertTrue(listB.isEmpty());
+        Assert.assertThat(listB, is(empty()));
 	}
 	
 }

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue18TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue18TestCase.java
@@ -30,6 +30,13 @@ import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
 import ma.glasnost.orika.metadata.ClassMapBuilder;
 
+/**
+ * NoSuchElementException mapping empty lists.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/18">https://code.google.com/archive/p/orika/</a>
+ *
+ */
 public class Issue18TestCase {
 
 	

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue19TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue19TestCase.java
@@ -23,6 +23,13 @@ import ma.glasnost.orika.impl.DefaultMapperFactory;
 
 import org.junit.Test;
 
+/**
+ * Copying objects works only first time.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/19">https://code.google.com/archive/p/orika/</a>
+ *
+ */
 public class Issue19TestCase {
 	
 	@Test

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue20TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue20TestCase.java
@@ -41,8 +41,12 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
 
-
 /**
+ * StackOverflowError mapping hibernate4 proxy.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/20">https://code.google.com/archive/p/orika/</a>
+ *
  * @author Dmitriy Khomyakov
  * @author matt.deboer@gmail.com
  */

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue21TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue21TestCase.java
@@ -47,10 +47,11 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
-
 /**
+ * NPE when collection is changed.
  * <p>
- * </p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/21">https://code.google.com/archive/p/orika/</a>
  * 
  * @author Dmitriy Khomyakov
  * @author matt.deboer@gmail.com
@@ -72,7 +73,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @DirtiesContext
 public class Issue21TestCase {
-
+    
 	@Autowired
 	private SessionFactory sessionFactory;
 	private Serializable user1Id;

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue24TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue24TestCase.java
@@ -19,7 +19,6 @@
 package ma.glasnost.orika.test.community;
 
 import ma.glasnost.orika.MapperFactory;
-import ma.glasnost.orika.MappingContext;
 import ma.glasnost.orika.metadata.ClassMapBuilder;
 import ma.glasnost.orika.metadata.Type;
 import ma.glasnost.orika.metadata.TypeFactory;
@@ -28,10 +27,10 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Issue 24:    
- *      lookupConcreteDestinationType should return the most specific type, 
- *      not the first that is assignable
+ * lookupConcreteDestinationType should return the most specific type, not the first that is assignable.
+ * <p>
  * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/24">https://code.google.com/archive/p/orika/</a>
  * @author mattdeboer
  *
  */

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue25TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue25TestCase.java
@@ -52,6 +52,13 @@ import org.junit.Before;
 import org.junit.Test;
 
 
+/**
+ * Add customization of collection mapping.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/25">https://code.google.com/archive/p/orika/</a>
+ *
+ */
 public class Issue25TestCase extends BaseManufacturingFacilityTest{
 
 	private MapperFacade mapper = null; 

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue25TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue25TestCase.java
@@ -17,7 +17,8 @@
  */
 package ma.glasnost.orika.test.community;
 
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,7 +39,6 @@ import ma.glasnost.orika.impl.DefaultMapperFactory;
 import ma.glasnost.orika.impl.UtilityResolver;
 import ma.glasnost.orika.impl.generator.EclipseJdtCompilerStrategy;
 import ma.glasnost.orika.metadata.Type;
-import ma.glasnost.orika.metadata.TypeBuilder;
 import ma.glasnost.orika.metadata.TypeFactory;
 import ma.glasnost.orika.test.community.issue25.BaseManufacturingFacilityTest;
 import ma.glasnost.orika.test.community.issue25.CustomOrikaMapper;
@@ -82,7 +82,7 @@ public class Issue25TestCase extends BaseManufacturingFacilityTest{
 
         ManufacturingFacilityDTS betriebsstaetteDTSMapped = mapper.map(manufacturingFacility, ManufacturingFacilityDTS.class);
         ManufacturingFacility betriebsstaetteMappedBack = mapper.map(betriebsstaetteDTSMapped, ManufacturingFacility.class);
-        assertTrue(manufacturingFacility.equals(betriebsstaetteMappedBack));
+        assertThat(manufacturingFacility, is(betriebsstaetteMappedBack));
     }
     
     @Test
@@ -97,7 +97,7 @@ public class Issue25TestCase extends BaseManufacturingFacilityTest{
 
         ManufacturingFacilityDTS betriebsstaetteDTSMapped = mapper.map(manufacturingFacility, ManufacturingFacilityDTS.class);
         ManufacturingFacility betriebsstaetteMappedBack = mapper.map(betriebsstaetteDTSMapped, ManufacturingFacility.class);
-        assertTrue(manufacturingFacility.equals(betriebsstaetteMappedBack));
+        assertThat(manufacturingFacility, is(betriebsstaetteMappedBack));
     }
     
     @Test
@@ -114,7 +114,7 @@ public class Issue25TestCase extends BaseManufacturingFacilityTest{
 
         ManufacturingFacilityDTS betriebsstaetteDTSMapped = mapper.map(manufacturingFacility, ManufacturingFacilityDTS.class);
         ManufacturingFacility betriebsstaetteMappedBack = mapper.map(betriebsstaetteDTSMapped, ManufacturingFacility.class);
-        assertTrue(manufacturingFacility.equals(betriebsstaetteMappedBack));
+        assertThat(manufacturingFacility, is(betriebsstaetteMappedBack));
     }
     
     @Test
@@ -160,24 +160,23 @@ public class Issue25TestCase extends BaseManufacturingFacilityTest{
         mapper.map(manufacturingFacilityToEdit, prototype);
         
         // Do some checks.
-        assertTrue("IdNumber was not kept after merge.", 
-        			4L == prototype.getIdNumber());
+        assertThat("IdNumber was not kept after merge.", prototype.getIdNumber(), is(4L));
         
         // Check name of street
-        assertTrue("Street new".equals(prototype.getAddressL().get(0).getStreet()));
+        assertThat(prototype.getAddressL().get(0).getStreet(), is("Street new"));
         
         // Amount of addresses
         List<AddressDTO> addressesFromPrototype = prototype.getAddressL();
-        assertTrue("An address was removed. In the merged DS this address does still exist.", 
-                   addressesFromPrototype.size() == 2);
+        assertThat("An address was removed. In the merged DS this address does still exist.",
+                addressesFromPrototype.size(), is(2));
         
         // land check
         List<AddressDTO> addressesAfterMerge = prototype.getAddressL();
         AddressDTO addressOne = addressesAfterMerge.get(0);
         AddressDTO addressTwo = addressesAfterMerge.get(1);
 
-        assertTrue("Land after merge is wrong.", Character.valueOf('D').equals(addressOne.getLand()));
-        assertTrue("Land after merge is wrong.", Character.valueOf('D').equals(addressTwo.getLand()));
+        assertThat("Land after merge is wrong.", addressOne.getLand(), is(Character.valueOf('D')));
+        assertThat("Land after merge is wrong.", addressTwo.getLand(), is(Character.valueOf('D')));
     }
     
     

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue26TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue26TestCase.java
@@ -29,6 +29,13 @@ import ma.glasnost.orika.test.community.issue26.OrderIDConverter;
 
 import org.junit.Test;
 
+/**
+ * Generic super-type not recognized.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/26">https://code.google.com/archive/p/orika/</a>
+ *
+ */
 public class Issue26TestCase {
 
 	@Test

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue28TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue28TestCase.java
@@ -30,6 +30,13 @@ import ma.glasnost.orika.test.community.issue28.OrderData;
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * StackoverflowException on recursively-defined generic type.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/28">https://code.google.com/archive/p/orika/</a>
+ *
+ */
 public class Issue28TestCase {
     @Test
     public void testMapping() {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue30TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue30TestCase.java
@@ -17,10 +17,14 @@
  */
 package ma.glasnost.orika.test.community;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Assert;
 import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
 import ma.glasnost.orika.metadata.ClassMapBuilder;
@@ -162,11 +166,10 @@ public class Issue30TestCase {
 				InventoryDTO.class);
 		
 		
-		Assert.assertTrue(inventory.getItems().size() == inventoryDTO
-				.getItems().size());
+        assertThat(inventory.getItems(), hasSize(inventoryDTO.getItems().size()));
 		
 		for (Object o: inventoryDTO.getItems()) {
-			Assert.assertTrue(o instanceof ComputerPartDTO);
+            assertThat(o, is(instanceOf(ComputerPartDTO.class)));
 		}
 	}
 }

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue30TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue30TestCase.java
@@ -33,6 +33,13 @@ import ma.glasnost.orika.metadata.TypeBuilder;
 
 import org.junit.Test;
 
+/**
+ * MappingException: cannot determine runtime type of destination collection.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/30">https://code.google.com/archive/p/orika/</a>
+ *
+ */
 public class Issue30TestCase {
 
 	public static abstract class ComputerPart {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue34TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue34TestCase.java
@@ -26,9 +26,10 @@ import ma.glasnost.orika.unenhance.HibernateUnenhanceStrategy;
 import org.junit.Test;
 
 /**
+ * The mapper create a child's instance instead of a parent's instance.
  * <p>
- * </p>
  * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/34">https://code.google.com/archive/p/orika/</a>
  * @author Dmitriy Khomyakov
  */
 public class Issue34TestCase {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue38TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue38TestCase.java
@@ -25,6 +25,12 @@ import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.metadata.ClassMapBuilder;
 import ma.glasnost.orika.test.MappingUtil;
 
+/**
+ * Want to have option to not set target object property when property value in the source object is null.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/38">https://code.google.com/archive/p/orika/</a>
+ */
 public class Issue38TestCase {
 
 	@Test

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue41TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue41TestCase.java
@@ -21,7 +21,6 @@ package ma.glasnost.orika.test.community;
 import org.junit.Assert;
 import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.impl.ConfigurableMapper;
-import ma.glasnost.orika.metadata.ClassMapBuilder;
 import ma.glasnost.orika.test.ConcurrentRule.Concurrent;
 import ma.glasnost.orika.test.community.issue41.MyEnum;
 import ma.glasnost.orika.test.community.issue41.MyEnumConverter;
@@ -30,6 +29,12 @@ import ma.glasnost.orika.test.community.issue41.MyTargetObject;
 
 import org.junit.Test;
 
+/**
+ * StackOverflowError for nested Enum.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/41">https://code.google.com/archive/p/orika/</a>
+ */
 public class Issue41TestCase {
     
     @Test

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue44TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue44TestCase.java
@@ -36,6 +36,12 @@ import ma.glasnost.orika.metadata.Type;
 
 import org.junit.Test;
 
+/**
+ * Allow converters for Lists (or other collections).
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/44">https://code.google.com/archive/p/orika/</a>
+ */
 public class Issue44TestCase {
     
     @Test

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue45TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue45TestCase.java
@@ -28,7 +28,10 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
+ * resolveSourceType does not distinguish by destinationType.
+ * <p>
  * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/45">https://code.google.com/archive/p/orika/</a>
  */
 public class Issue45TestCase {
     

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue46TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue46TestCase.java
@@ -28,6 +28,12 @@ import ma.glasnost.orika.test.MappingUtil;
 
 import org.junit.Test;
 
+/**
+ * Class-cast exception for mapped objects.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/46">https://code.google.com/archive/p/orika/</a>
+ */
 public class Issue46TestCase {
     public static class One {
         public List<Two> getTwos() {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue49TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue49TestCase.java
@@ -26,8 +26,11 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Verify that we use Enum.name istead of Enum.toString
+ * MappingException when enum toString() is overridden.
+ * <p>
+ * Verify that we use Enum.name instead of Enum.toString
  * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/49">https://code.google.com/archive/p/orika/</a>
  * @author Dmitriy Khomyakov
  */
 public class Issue49TestCase {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue50TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue50TestCase.java
@@ -25,6 +25,10 @@ import ma.glasnost.orika.impl.generator.EclipseJdtCompilerStrategy;
 import org.junit.Test;
 
 /**
+ * Exclusions are ignored when combined with used mappers.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/50">https://code.google.com/archive/p/orika/</a>
  * @author matt.deboer@gmail.com
  * 
  */

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue52aTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue52aTestCase.java
@@ -24,6 +24,10 @@ import ma.glasnost.orika.impl.DefaultMapperFactory;
 import org.junit.Test;
 
 /**
+ * StackOverflowError when using inheritance mapping.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/52">https://code.google.com/archive/p/orika/</a>
  * @author matt.deboer@gmail.com
  *
  */

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue52bTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue52bTestCase.java
@@ -25,6 +25,10 @@ import ma.glasnost.orika.impl.DefaultMapperFactory;
 import org.junit.Test;
 
 /**
+ * StackOverflowError when using inheritance mapping.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/52">https://code.google.com/archive/p/orika/</a>
  * @author matt.deboer@gmail.com
  *
  */

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue53TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue53TestCase.java
@@ -20,11 +20,17 @@ package ma.glasnost.orika.test.community;
 import static org.junit.Assert.assertEquals;
 import ma.glasnost.orika.MapperFacade;
 import ma.glasnost.orika.MapperFactory;
-import ma.glasnost.orika.impl.DefaultMapperFactory;
 import ma.glasnost.orika.test.MappingUtil;
 
 import org.junit.Test;
 
+/**
+ * Dynamic mapping always uses existing parent mapper even if it doesn't map all fields.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/53">https://code.google.com/archive/p/orika/</a>
+ *
+ */
 public class Issue53TestCase {
     
     @Test

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue61TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue61TestCase.java
@@ -27,9 +27,10 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
+ * StackOverflowError on circle association
  * <p>
- * </p>
  * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/61">https://code.google.com/archive/p/orika/</a>
  * @author Dmitriy Khomyakov
  */
 public class Issue61TestCase {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue64Test.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue64Test.java
@@ -13,6 +13,12 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+/**
+ * Orika does not create intermediate property when mapping lists.
+ * <p>
+ * 
+ * @see <a href="https://github.com/orika-mapper/orika/issues/64">https://github.com/orika-mapper/orika/issues</a>
+ */
 public class Issue64Test {
 
     private final MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue64TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue64TestCase.java
@@ -29,6 +29,10 @@ import ma.glasnost.orika.test.MappingUtil;
 import org.junit.Test;
 
 /**
+ * SimpleConstructorResolverStrategy ignores generic parameter types
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/64">https://code.google.com/archive/p/orika/</a>
  * @author matt.deboer@gmail.com
  *
  */

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue65TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue65TestCase.java
@@ -26,6 +26,10 @@ import ma.glasnost.orika.test.MappingUtil;
 import org.junit.Test;
 
 /**
+ * Orika wraps user exceptions in MapperException
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/65">https://code.google.com/archive/p/orika/</a>
  * @author matt.deboer@gmail.com
  *
  */

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue67Test.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue67Test.java
@@ -12,6 +12,12 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+/**
+ * NPE on VariableRef.isPrimitive() with map of map.
+ * <p>
+ * 
+ * @see <a href="https://github.com/orika-mapper/orika/issues/67">https://github.com/orika-mapper/orika/issues</a>
+ */
 public class Issue67Test {
 
     private MapperFactory mapperFactory;

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue67TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue67TestCase.java
@@ -24,6 +24,14 @@ import ma.glasnost.orika.MapperFacade;
 import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
 
+/**
+ * Property with no getter (null readMethod) is not being excluded/ignored
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/67">https://code.google.com/archive/p/orika/</a>
+ * @author matt.deboer@gmail.com
+ *
+ */
 public class Issue67TestCase {
 
 	@Test

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue68TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue68TestCase.java
@@ -33,6 +33,13 @@ import ma.glasnost.orika.impl.ConfigurableMapper;
 import org.junit.Test;
 
 
+/**
+ * How to handle infinit recursion for entities with bidirectional many-to-many relations.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/68">https://code.google.com/archive/p/orika/</a>
+ *
+ */
 public class Issue68TestCase {
 
 	@Test

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue68TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue68TestCase.java
@@ -17,6 +17,10 @@
  */
 package ma.glasnost.orika.test.community;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -56,11 +60,14 @@ public class Issue68TestCase {
 
 		invoiceitemVO.getProjectItems().add(projectItemVO);
 
-		InvoiceItemProxy invoiceItemProxy = BeanFactory
-				.createInvoiceItemProxy();
+        InvoiceItemProxy invoiceItemProxy = BeanFactory.createInvoiceItemProxy();
 		mapper.map(invoiceitemVO, invoiceItemProxy);
 
+        ProjectProxy projectProxy = BeanFactory.createProjectProxy();
+        mapper.map(projectVO, projectProxy);
 
+        assertThat(projectVO.getName(), is(projectProxy.getName()));
+        assertThat(projectVO.getProjectItems(), hasSize(projectProxy.getProjectItems().size()));
 	}
 
 	public static class BeanFactory {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue69TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue69TestCase.java
@@ -33,6 +33,10 @@ import ma.glasnost.orika.test.MappingUtil;
 import org.junit.Test;
 
 /**
+ * Orika fails to map classes with lists which do not return internal references.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/69">https://code.google.com/archive/p/orika/</a>
  * @author matt.deboer@gmail.com
  *
  */

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue71TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue71TestCase.java
@@ -27,7 +27,10 @@ import ma.glasnost.orika.impl.DefaultMapperFactory;
 import org.junit.Test;
 
 /**
- * @author 
+ * Orika maps enum to enum, but not List&lt;enum&gt; to List&lt;enum&gt;.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/71">https://code.google.com/archive/p/orika/</a>
  *
  */
 public class Issue71TestCase {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue77Test.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue77Test.java
@@ -14,6 +14,12 @@ import static com.google.common.collect.Sets.newHashSet;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Invalid code generated when embedded field name not a valid java variable name.
+ * <p>
+ * 
+ * @see <a href="https://github.com/orika-mapper/orika/issues/77">https://github.com/orika-mapper/orika/issues</a>
+ */
 public class Issue77Test {
 
     @Test

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue77TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue77TestCase.java
@@ -31,6 +31,13 @@ import ma.glasnost.orika.impl.DefaultMapperFactory;
 
 import org.junit.Test;
 
+/**
+ * A sub type is not being mapped to the configured mapping type.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/77">https://code.google.com/archive/p/orika/</a>
+ *
+ */
 public class Issue77TestCase {
     
     public static class A1 {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue77TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue77TestCase.java
@@ -18,6 +18,8 @@
 
 package ma.glasnost.orika.test.community;
 
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 
 import java.util.ArrayList;
@@ -106,8 +108,8 @@ public class Issue77TestCase {
         final Container2 c2 = mapper.map(c1, Container2.class);
 
         // check
-        assertTrue(c1.singleElement instanceof B1);
-        assertTrue(c2.singleElement instanceof B2);
-        assertTrue(c2.elements.get(0) instanceof B2);
+        assertThat(c1.singleElement, is(instanceOf(B1.class)));
+        assertThat(c2.singleElement, is(instanceOf(B2.class)));
+        assertThat(c2.elements.get(0), is(instanceOf(B2.class)));
     }  
 }

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue80TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue80TestCase.java
@@ -27,6 +27,14 @@ import ma.glasnost.orika.test.MappingUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * There is a bug for JavaBean to Map.
+ * <p>
+ * I define a class like this: public class JsonObject extends HashMap<String,Object>{...}. Orika can not map JavaBean to JsonObject.
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/80">https://code.google.com/archive/p/orika/</a>
+ *
+ */
 public class Issue80TestCase {
     
     public static class JsonObject extends HashMap<String,Object> {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue82TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue82TestCase.java
@@ -35,6 +35,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
+ * MappingException on customization the default field-name mapping.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/82">https://code.google.com/archive/p/orika/</a>
  * @author Alexey Salnikov
  */
 public class Issue82TestCase {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue85TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue85TestCase.java
@@ -28,13 +28,15 @@ import ma.glasnost.orika.test.MappingUtil;
 import org.junit.Test;
 
 /**
+ * NullPointerException in MultiOccurrenceToMultiOccurrence.mapFields.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/85">https://code.google.com/archive/p/orika/</a>
  * @author conleym
  * 
  */
 public final class Issue85TestCase {
-    /**
-     * @param args
-     */
+    
     @Test
     public void test() {
         MapperFactory f = MappingUtil.getMapperFactory();

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue87TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue87TestCase.java
@@ -26,6 +26,13 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+/**
+ * Nested properties: Allow abstract nested property's fields mapping.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/87">https://code.google.com/archive/p/orika/</a>
+ * 
+ */
 public class Issue87TestCase {
 
     private MapperFactory mapperFactory;

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue90TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue90TestCase.java
@@ -24,6 +24,25 @@ import ma.glasnost.orika.impl.DefaultMapperFactory;
 
 import org.junit.Test;
 
+/**
+ * Simple mappings fail.
+ * <p>
+ * I am trying to map type A to C, then B to C. I could reproduce with really simple classes, A, B, C being a class with a single string
+ * attribute named "s".
+ * <p>
+ * This fails with exception "B is an unsupported source class". Looks like Orika uses the first converter: it expects A and gets B instead.
+ * <p>
+ * The exception goes away when I explicitly register the mappings A->C, B->C. This is tedious because this forces me to register all
+ * possible mappings (a lot in my case!) during initialization.
+ * <p>
+ * Please check out attached test case.
+ * <p>
+ * I could reproduce the issue with Orika 1.4.1 and 1.4.2-SNAPSHOT.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/90">https://code.google.com/archive/p/orika/</a>
+ * 
+ */
 public class Issue90TestCase {
 
     public static class A {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue91Test.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue91Test.java
@@ -6,17 +6,20 @@ import ma.glasnost.orika.OrikaSystemProperties;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertNotNull;
 
+/**
+ * No concrete class mapping defined error mapping a list of interfaces.
+ * <p>
+ * 
+ * @see <a href="https://github.com/orika-mapper/orika/issues/91">https://github.com/orika-mapper/orika/issues</a>
+ */
 public class Issue91Test {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     private MapperFacade mapperFacade;
 
     @Before

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue92TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue92TestCase.java
@@ -33,6 +33,13 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+/**
+ * NPE when mapping a class implementing a map.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/92">https://code.google.com/archive/p/orika/</a>
+ * 
+ */
 public class Issue92TestCase {
 
         private MapperFactory factory;

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue98TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue98TestCase.java
@@ -30,6 +30,13 @@ import ma.glasnost.orika.impl.ConfigurableMapper;
 
 import org.junit.Test;
 
+/**
+ * ClassCastException when mapping list of subtypes.
+ * <p>
+ * 
+ * @see <a href="https://code.google.com/archive/p/orika/issues/98">https://code.google.com/archive/p/orika/</a>
+ * 
+ */
 public class Issue98TestCase {
     
     @Test

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue99Test.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue99Test.java
@@ -11,6 +11,12 @@ import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Registering map with multiple converters does not work.
+ * <p>
+ * 
+ * @see <a href="https://github.com/orika-mapper/orika/issues/99">https://github.com/orika-mapper/orika/issues</a>
+ */
 public class Issue99Test {
     @Test
     public void testDateMapping() throws Exception {

--- a/tests/src/main/java/ma/glasnost/orika/test/community/PullRequest10TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/PullRequest10TestCase.java
@@ -29,7 +29,13 @@ import ma.glasnost.orika.metadata.TypeFactory;
 
 import org.junit.Test;
 
-public class PullRequest9TestCase {
+/**
+ * Correctly implement compareTo contract for Type.
+ * <p>
+ * 
+ * @see <a href="https://github.com/orika-mapper/orika/pull/10">https://github.com/orika-mapper/orika</a>
+ */
+public class PullRequest10TestCase {
 	public static class Base {
 	}
 

--- a/tests/src/main/java/ma/glasnost/orika/test/community/PullRequest88TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/PullRequest88TestCase.java
@@ -16,7 +16,12 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
-
+/**
+ * Do not loose Map instance when mapping MultiOccurenceVariable to a Map.
+ * <p>
+ * 
+ * @see <a href="https://github.com/orika-mapper/orika/pull/88">https://github.com/orika-mapper/orika</a>
+ */
 public class PullRequest88TestCase {
     public static final Type<Set<A>> SET = new TypeBuilder<Set<A>>() {}.build();
     public static final Type<Map<String, String>> MAP = new TypeBuilder<Map<String, String>>() {}.build();

--- a/tests/src/main/java/ma/glasnost/orika/test/community/PullRequest8TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/PullRequest8TestCase.java
@@ -24,7 +24,10 @@ import ma.glasnost.orika.impl.DefaultConstructorObjectFactory;
 import ma.glasnost.orika.metadata.TypeFactory;
 import ma.glasnost.orika.test.MappingUtil;
 
-import org.junit.Assert;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
 import org.junit.Test;
 
 public class PullRequest8TestCase {
@@ -52,6 +55,6 @@ public class PullRequest8TestCase {
 		ObjectFactory<MyType> myFactory = factory.lookupObjectFactory(
 				TypeFactory.valueOf(MyType.class),
 				TypeFactory.valueOf(MySourceType.class));
-		Assert.assertTrue(myFactory instanceof MyObjectFactory);
+        assertThat(myFactory, is(instanceOf(MyObjectFactory.class)));
 	}
 }

--- a/tests/src/main/java/ma/glasnost/orika/test/community/PullRequest8TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/PullRequest8TestCase.java
@@ -30,6 +30,12 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.Test;
 
+/**
+ * lookupObjectFactory should consider superclasses for source type.
+ * <p>
+ * 
+ * @see <a href="https://github.com/orika-mapper/orika/pull/8">https://github.com/orika-mapper/orika</a>
+ */
 public class PullRequest8TestCase {
 	public static class MySourceType {
 	}

--- a/tests/src/main/java/ma/glasnost/orika/test/community/PullRequest9TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/PullRequest9TestCase.java
@@ -18,6 +18,8 @@
 
 package ma.glasnost.orika.test.community;
 
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 import java.util.Arrays;
 import java.util.List;
@@ -62,25 +64,26 @@ public class PullRequest9TestCase {
 		
 		for (Type<?> x : types) {
 			for (Type<?> y : types) {
-				assertTrue("sgn(x.compareTo(y)) == -sgn(y.compareTo(x)) for x="
-						+ x.getSimpleName() + ", y=" + y.getSimpleName(),
-						sgn(x.compareTo(y)) == -sgn(y.compareTo(x)));
+                assertThat("sgn(x.compareTo(y)) == -sgn(y.compareTo(x)) for x="
+                        + x.getSimpleName() + ", y=" + y.getSimpleName(),
+                        sgn(x.compareTo(y)), is(-sgn(y.compareTo(x))));
 				
 				for (Type<?> z : types) {
 					if (x.compareTo(y) > 0 && y.compareTo(z) > 0) {
-						assertTrue(
+                        assertThat(
 								"(x.compareTo(y)>0 && y.compareTo(z)>0) implies x.compareTo(z)>0 for x="
 										+ x.getSimpleName() + ", y="
 										+ y.getSimpleName() + ", z="
-										+ z.getSimpleName(), x.compareTo(z) > 0);
+                                        + z.getSimpleName(),
+                                x.compareTo(z), is(greaterThan(0)));
 					}
 					if (x.compareTo(y) == 0) {
-						assertTrue(
+                        assertThat(
 								"x.compareTo(y)==0 implies sgn(x.compareTo(z)) == sgn(y.compareTo(z)) for x="
 										+ x.getSimpleName() + ", y="
 										+ y.getSimpleName() + ", z="
 										+ z.getSimpleName(),
-								sgn(x.compareTo(z)) == sgn(y.compareTo(z)));
+                                sgn(x.compareTo(z)), is(sgn(y.compareTo(z))));
 					}
 				}
 			}


### PR DESCRIPTION
Hi,

Improved TestCases:
 - The most part on the TestCases where the additional JavaDoc because some TestCases reference the Issue-Id from google-group and some TestCases reference the Issue-Id from GitHub

Add default Mappings for java-8 DateTime Api immutable classes.
 - This fixes #170 and #96

Update README.md: Add Badges to show and link the most important parts:
 * Last Build: [![Build Status](https://secure.travis-ci.org/orika-mapper/orika.png)](http://travis-ci.org/orika-mapper/orika)
 * GitHub-Site: [![GitHub site](https://img.shields.io/badge/GitHub-site-blue.svg)](http://orika-mapper.github.com/orika-docs/)
 * Latest Released Version: [![Maven Central](https://maven-badges.herokuapp.com/maven-central/ma.glasnost.orika/orika-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/ma.glasnost.orika/orika-core)
 * JavaDoc: [![Javadocs](http://www.javadoc.io/badge/ma.glasnost.orika/orika-core.svg)](http://www.javadoc.io/doc/ma.glasnost.orika/orika-core)
 * License: [![License: Apache 2.0](https://img.shields.io/badge/license-Apache_2.0-brightgreen.svg)](https://github.com/orika-mapper/orika/blob/master/LICENSE)