### PR TITLE
Fix objectfactory selection

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/impl/DefaultMapperFactory.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/DefaultMapperFactory.java
@@ -970,18 +970,19 @@ public class DefaultMapperFactory implements MapperFactory, Reportable {
             return null;
         }
         
+        ConcurrentHashMap<Type<? extends Object>, ObjectFactory<? extends Object>> objFactoryCacheForDestType = objectFactoryRegistry
+                .get(destinationType);
+        if (objFactoryCacheForDestType != null) {
+            ObjectFactory<T> result = findObjectFactory(objFactoryCacheForDestType, sourceType, false);
+            if (result != null) {
+                return result;
+            }
+        }
+        
         Set<Type<? extends Object>> objFactoryDestTypes = getKeys(objectFactoryRegistry);
         for (Type<? extends Object> objFactoryDestType : objFactoryDestTypes) {
-            ConcurrentHashMap<Type<? extends Object>, ObjectFactory<? extends Object>> objFactoryCachePerSrcType = objectFactoryRegistry
-                    .get(objFactoryDestType);
-            
-            if (destinationType.equals(objFactoryDestType)) {
-                ObjectFactory<T> result = findObjectFactory(objFactoryCachePerSrcType, sourceType, false);
-                if (result != null) {
-                    return result;
-                }
-            } else if (destinationType.isAssignableFrom(objFactoryDestType)) {
-                ObjectFactory<T> result = findObjectFactory(objFactoryCachePerSrcType, sourceType, true);
+            if (destinationType.isAssignableFrom(objFactoryDestType)) {
+                ObjectFactory<T> result = findObjectFactory(objectFactoryRegistry.get(objFactoryDestType), sourceType, true);
                 if (result != null) {
                     return result;
                 }

--- a/tests/src/main/java/ma/glasnost/orika/test/objectfactory/CustomFactory.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/objectfactory/CustomFactory.java
@@ -1,0 +1,24 @@
+package ma.glasnost.orika.test.objectfactory;
+
+import java.lang.reflect.Constructor;
+
+import ma.glasnost.orika.MappingContext;
+import ma.glasnost.orika.ObjectFactory;
+
+public class CustomFactory<T> implements ObjectFactory<T> {
+	private Class<T> type;
+
+	public CustomFactory(Class<T> type) {
+		this.type = type;
+	}
+
+	public T create(Object o, MappingContext mappingContext) {
+		try {
+			Constructor<T> declaredConstructor = type.getDeclaredConstructor();
+			declaredConstructor.setAccessible(true);
+			return declaredConstructor.newInstance();
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/tests/src/main/java/ma/glasnost/orika/test/objectfactory/MultipleObjectFactoryTest.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/objectfactory/MultipleObjectFactoryTest.java
@@ -1,0 +1,35 @@
+package ma.glasnost.orika.test.objectfactory;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import ma.glasnost.orika.MapperFacade;
+import ma.glasnost.orika.MapperFactory;
+import ma.glasnost.orika.impl.DefaultMapperFactory;
+import ma.glasnost.orika.impl.generator.EclipseJdtCompilerStrategy;
+import ma.glasnost.orika.metadata.TypeFactory;
+
+public class MultipleObjectFactoryTest {
+	public static class Base {
+	}
+
+	public static class Sub1 extends Base {
+	}
+
+	public static class Sub2 extends Base {
+	}
+
+	@Test
+	public void orikaTest() {
+		MapperFactory factory = new DefaultMapperFactory.Builder().compilerStrategy(new EclipseJdtCompilerStrategy())
+				.build();
+
+		factory.registerObjectFactory(new CustomFactory<Sub1>(Sub1.class), TypeFactory.<Sub1>valueOf(Sub1.class));
+		factory.registerObjectFactory(new CustomFactory<Sub2>(Sub2.class), TypeFactory.<Sub2>valueOf(Sub2.class));
+		factory.registerObjectFactory(new CustomFactory<Base>(Base.class), TypeFactory.<Base>valueOf(Base.class));
+
+		MapperFacade mapperFacade = factory.getMapperFacade();
+		Base mapped = mapperFacade.map(new Object(), Base.class);
+		assertEquals("returned instance is not Base", Base.class, mapped.getClass());
+	}
+}


### PR DESCRIPTION
#176 causes a regression in the way ObjectFactories are selected. Given a type hierarchy with Base and Sub1 and Sub2, both extending Base, a factory for Sub1 or Sub2 might be returned when looking up a factory for Base. When a perfect match exists, it should always prefer that factory.

This PR fixes the issue and adds a testcase demonstrating the problem.