### PR TITLE
Fix mapAsList with list of proxies with different types

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/impl/MapperFacadeImpl.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/MapperFacadeImpl.java
@@ -786,9 +786,10 @@ public class MapperFacadeImpl implements MapperFacade, Reportable {
      * @return
      */
     private <S, D> D mapElement(S source, ElementStrategyContext<S, D> context) {
-        if (context.strategy == null || !source.getClass().equals(context.sourceClass)) {
+    	Class<?> sourceClass = getClass(source);
+        if (context.strategy == null || !sourceClass.equals(context.sourceClass)) {
             context.strategy = resolveMappingStrategy(source, context.sourceType, context.destinationType, false, context.mappingContext);
-            context.sourceClass = source.getClass();
+            context.sourceClass = sourceClass;
         } else {
             context.mappingContext.setResolvedSourceType(context.sourceType);
             context.mappingContext.setResolvedDestinationType(context.destinationType);

--- a/tests/src/main/java/ma/glasnost/orika/test/unenhance/inheritance/HibernateProxyTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/unenhance/inheritance/HibernateProxyTestCase.java
@@ -19,11 +19,8 @@
 package ma.glasnost.orika.test.unenhance.inheritance;
 
 import java.io.Serializable;
-
-import ma.glasnost.orika.MapperFacade;
-import ma.glasnost.orika.MapperFactory;
-import ma.glasnost.orika.impl.DefaultMapperFactory;
-import ma.glasnost.orika.unenhance.HibernateUnenhanceStrategy;
+import java.util.Arrays;
+import java.util.List;
 
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -38,6 +35,11 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
 
+import ma.glasnost.orika.MapperFacade;
+import ma.glasnost.orika.MapperFactory;
+import ma.glasnost.orika.impl.DefaultMapperFactory;
+import ma.glasnost.orika.unenhance.HibernateUnenhanceStrategy;
+
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "classpath:HibernateProxyTestCase-context.xml")
 @Transactional
@@ -46,6 +48,7 @@ public class HibernateProxyTestCase {
 	@Autowired
 	private SessionFactory sessionFactory;
 
+	private Serializable sub1Id;
 	private Serializable sub21Id;
 	private Serializable sub22Id;
 
@@ -58,7 +61,7 @@ public class HibernateProxyTestCase {
 		Sub1Entity sub1 = new Sub1Entity();
 		sub1.setMyProperty("my property on sub1");
 		sub1.setSub1Property(1);
-		getSession().save(sub1);
+		sub1Id = getSession().save(sub1);
 
 		Sub2Entity sub21 = new Sub2Entity();
 		sub21.setMyProperty("my property on sub2");
@@ -144,5 +147,19 @@ public class HibernateProxyTestCase {
 		
 		Assert.assertEquals(Sub1EntityDTO.class, sub21Dto.getReferences().getClass());
 		Assert.assertEquals(Sub2EntityDTO.class, sub22Dto.getReferences().getClass());
+	}
+
+	@Test
+	public void testMappingCollections() {
+		MapperFacade mapper = buildMapper();
+
+		List<MyEntity> entities = Arrays.asList((MyEntity) getSession().load(MyEntity.class, sub22Id),
+				(MyEntity) getSession().load(MyEntity.class, sub21Id),
+				(MyEntity) getSession().load(MyEntity.class, sub1Id));
+		
+		List<MyEntityDTO> mappedList = mapper.mapAsList(entities, MyEntityDTO.class);
+		Assert.assertEquals(Sub2EntityDTO.class, mappedList.get(0).getClass());
+		Assert.assertEquals(Sub2EntityDTO.class, mappedList.get(1).getClass());
+		Assert.assertEquals(Sub1EntityDTO.class, mappedList.get(2).getClass());
 	}
 }


### PR DESCRIPTION
This patch fixes mapAsList to correctly resolve the types of the elements in the collection using the unenhance strategy. I'm not sure if the use of getClass(source) is correct (which uses userUnenhanceStrategy), or if unenhanceStrategy should be used. The change does fix the added testcase.