### PR TITLE
Date and Time objects to Object fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: false
 language: java
 jdk:
-  - oraclejdk7
+  - openjdk7
   - oraclejdk8
+  - oraclejdk9
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: java
 jdk:
   - openjdk7
   - oraclejdk8
-  - oraclejdk9
 branches:
   only:
     - master

--- a/core/src/main/java/ma/glasnost/orika/converter/builtin/DateAndTimeConverters.java
+++ b/core/src/main/java/ma/glasnost/orika/converter/builtin/DateAndTimeConverters.java
@@ -560,7 +560,7 @@ public class DateAndTimeConverters {
     }
     
     public static boolean _polyCanConvert(Type<?> a, Type<?> b, Type<?> c, Type<?> d) {
-        return (a.isAssignableFrom(c)) && (d.isAssignableFrom(b));
+        return (a.isAssignableFrom(c)) && (!d.getRawType().equals(Object.class) && d.isAssignableFrom(b));
     }
     
     public static boolean polyCanConvert(Type<?> a, Type<?> b, Type<?> c, Type<?> d) {

--- a/tests/src/main/java/ma/glasnost/orika/test/BrokenTest.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/BrokenTest.java
@@ -1,0 +1,21 @@
+package ma.glasnost.orika.test;
+
+import ma.glasnost.orika.MapperFacade;
+import ma.glasnost.orika.MapperFactory;
+import ma.glasnost.orika.impl.DefaultMapperFactory;
+import org.junit.Test;
+
+import java.util.GregorianCalendar;
+
+public class BrokenTest {
+
+    @Test
+    public void testConvertingGregorianCalendar() {
+        MapperFactory mapperFactory = new DefaultMapperFactory.Builder()
+                .build();
+
+        MapperFacade mapperFacade = mapperFactory.getMapperFacade();
+        GregorianCalendar gc = new GregorianCalendar();
+        Object dest = mapperFacade.map(gc, Object.class);
+    }
+}


### PR DESCRIPTION
When checking assignments for XMLGregorian calendar, it checks if Object is assignableFrom things like XMLGregorianCalendar, which is true.  Since everything ultimately inherits from Object, this causes GregorianCalendar to match XMLGregorianCalendar, causing a cast issue.

Fixes #212