### PR TITLE
Update dependencies to support java 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ language: java
 jdk:
   - openjdk7
   - oraclejdk8
+  - oraclejdk9
 branches:
   only:
     - master
-
+    
 notifications:
   recipients:
     - elaatifi@gmail.com

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -104,13 +104,12 @@
 	        <plugin>
 	          <groupId>org.codehaus.mojo</groupId>
 	          <artifactId>animal-sniffer-maven-plugin</artifactId>
-	          <version>1.15</version>
+	          <version>1.16</version>
 	          <configuration>
-	            <signature>
-	              <groupId>org.codehaus.mojo.signature</groupId>
-	              <artifactId>java16</artifactId>
-	              <version>1.1</version>
-	            </signature>
+	          <jdk>
+            <version>[1.7.0)</version>
+            <vendor>sun</vendor>
+          </jdk>
 	          </configuration>
 	          <executions>
 	            <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -54,16 +54,15 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <javassist.version>3.19.0-GA</javassist.version>
-        <springframework.version>3.1.1.RELEASE</springframework.version>
-        <hibernate.version>3.3.2.GA</hibernate.version>
+        <javassist.version>3.22.0-GA</javassist.version>
+        <springframework.version>4.3.14.RELEASE</springframework.version>
+        <hibernate.version>5.0.12.Final</hibernate.version>
         <junit.version>4.12</junit.version>
-        <easymock.version>3.0</easymock.version>
-        <wagon-svn.version>1.8</wagon-svn.version>
-        <h2.version>1.3.154</h2.version>
-        <slf4j.version>1.6.6</slf4j.version>
+        <easymock.version>3.5.1</easymock.version>
+        <h2.version>1.4.196</h2.version>
+        <slf4j.version>1.7.25</slf4j.version>
         <paranamer.version>2.8</paranamer.version>
-        <logback.version>1.0.6</logback.version>
+        <logback.version>1.1.11</logback.version>
     </properties>
 
     <dependencyManagement>
@@ -97,7 +96,7 @@
             <dependency>
                 <groupId>org.codehaus.janino</groupId>
                 <artifactId>janino</artifactId>
-                <version>2.7.5</version>
+                <version>3.0.8</version>
                 <scope>test</scope>
             </dependency>
 
@@ -113,7 +112,7 @@
                 <version>${springframework.version}</version>
                 <scope>test</scope>
             </dependency>
-
+            
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-test</artifactId>
@@ -131,13 +130,13 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
-                <version>3.6.10.Final</version>
+                <version>${hibernate.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-entitymanager</artifactId>
-                <version>3.6.10.Final</version>
+                <version>${hibernate.version}</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
@@ -148,19 +147,11 @@
             </dependency>
 
             <dependency>
-                <groupId>org.hibernate</groupId>
+                <groupId>org.hibernate.common</groupId>
                 <artifactId>hibernate-commons-annotations</artifactId>
-                <version>3.2.0.Final</version>
+                <version>5.0.1.Final</version>
                 <scope>test</scope>
             </dependency>
-
-            <dependency>
-                <groupId>org.hsqldb</groupId>
-                <artifactId>hsqldb</artifactId>
-                <version>2.2.8</version>
-                <scope>test</scope>
-            </dependency>
-
 
             <dependency>
                 <groupId>com.h2database</groupId>
@@ -170,16 +161,16 @@
             </dependency>
 
             <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>2.5</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.7</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
-                <version>3.2.1</version>
+                <version>3.2.2</version>
                 <scope>test</scope>
             </dependency>
 
@@ -249,16 +240,9 @@
             <!-- END Eclipse Test dependencies -->
 
             <dependency>
-                <groupId>net.sf.dozer</groupId>
-                <artifactId>dozer</artifactId>
-                <version>5.3.2</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>com.google.caliper</groupId>
                 <artifactId>caliper</artifactId>
-                <version>0.5-rc1</version>
+                <version>1.0-beta-2</version>
                 <scope>test</scope>
             </dependency>
 
@@ -271,13 +255,19 @@
             <dependency>
                 <groupId>com.sun.xml.bind</groupId>
                 <artifactId>jaxb-impl</artifactId>
-                <version>2.2.7</version>
+                <version>2.3.0</version>
             </dependency>
-
+			
+			<dependency>
+				<groupId>javax.xml.bind</groupId>
+				<artifactId>jaxb-api</artifactId>
+				<version>2.3.0</version>
+			</dependency>
+			
             <dependency>
                 <groupId>com.carrotsearch</groupId>
                 <artifactId>java-sizeof</artifactId>
-                <version>0.0.4</version>
+                <version>0.0.5</version>
             </dependency>
 
             <dependency>
@@ -310,13 +300,14 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
 	    <plugin>
 	      <groupId>org.apache.maven.plugins</groupId>
 	      <artifactId>maven-javadoc-plugin</artifactId>
+	      <version>3.0.0</version>
 	      <configuration>
 		<additionalparam>-Xdoclint:none</additionalparam>
 	      </configuration>
@@ -329,21 +320,21 @@
         <plugins>
             <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.0.0</version>
             </plugin>
             <plugin>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>2.7.1</version>
+                <version>3.9.0</version>
                 <configuration>
                     <sourceEncoding>utf-8</sourceEncoding>
                     <minimumTokens>100</minimumTokens>
-                    <targetJdk>1.5</targetJdk>
+                    <targetJdk>1.7</targetJdk>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.1</version>
+                <version>2.7</version>
                 <configuration>
                     <formats>
                         <format>html</format>
@@ -354,7 +345,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.7.2</version>
+                <version>2.20.2</version>
                 <configuration>
                     <outputDirectory>${basedir}/target/surefire-reports</outputDirectory>
                 </configuration>
@@ -362,12 +353,12 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>jdepend-maven-plugin</artifactId>
-                <version>2.0-beta-2</version>
+                <version>2.0</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>2.4.0</version>
+                <version>3.0.5</version>
                 <configuration>
                     <xmlOutput>true</xmlOutput>
                     <effort>Max</effort>

--- a/tests-jdk8/pom.xml
+++ b/tests-jdk8/pom.xml
@@ -67,8 +67,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
 			<scope>compile</scope>
 		</dependency>
 

--- a/tests-jdk8/src/test/java/ma/glasnost/orika/test/jdk8/JavaDateApiTest.java
+++ b/tests-jdk8/src/test/java/ma/glasnost/orika/test/jdk8/JavaDateApiTest.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -60,7 +60,7 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.hibernate</groupId>
+			<groupId>org.hibernate.common</groupId>
 			<artifactId>hibernate-commons-annotations</artifactId>
 			<scope>compile</scope>
 			<exclusions>
@@ -102,8 +102,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
 			<scope>compile</scope>
 		</dependency>
 
@@ -118,6 +118,11 @@
 			<artifactId>spring-tx</artifactId>
 			<scope>compile</scope>
 		</dependency>
+		
+		<dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
 
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -135,7 +140,12 @@
 			<groupId>com.sun.xml.bind</groupId>
 			<artifactId>jaxb-impl</artifactId>
 		</dependency>
-
+		
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+		</dependency>
+		
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>

--- a/tests/src/main/java/ma/glasnost/orika/test/boundmapperfacade/GenericCollectionsTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/boundmapperfacade/GenericCollectionsTestCase.java
@@ -30,8 +30,8 @@ import ma.glasnost.orika.metadata.ClassMapBuilder;
 import ma.glasnost.orika.metadata.Type;
 import ma.glasnost.orika.metadata.TypeBuilder;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/tests/src/main/java/ma/glasnost/orika/test/common/types/TestCaseClasses.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/common/types/TestCaseClasses.java
@@ -21,10 +21,10 @@ package ma.glasnost.orika.test.common.types;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 public interface TestCaseClasses {
 

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue175Test.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue175Test.java
@@ -2,8 +2,8 @@ package ma.glasnost.orika.test.community;
 
 import ma.glasnost.orika.OrikaSystemProperties;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.junit.Test;
 
 import java.util.ArrayList;

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue176WithSuperClassesTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue176WithSuperClassesTestCase.java
@@ -7,7 +7,7 @@ import static org.hamcrest.Matchers.is;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
 import ma.glasnost.orika.CustomMapper;

--- a/tests/src/main/java/ma/glasnost/orika/test/community/issue121/util/RandomUtils.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/issue121/util/RandomUtils.java
@@ -1,8 +1,8 @@
 package ma.glasnost.orika.test.community.issue121.util;
 
-import org.apache.commons.lang.RandomStringUtils;
-
 import java.util.Random;
+
+import org.apache.commons.lang3.RandomStringUtils;
 
 /**
  * @author: Ilya Krokhmalyov YC14IK1

--- a/tests/src/main/java/ma/glasnost/orika/test/constructor/TestCaseClasses.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/constructor/TestCaseClasses.java
@@ -18,14 +18,14 @@
 
 package ma.glasnost.orika.test.constructor;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
-
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 import ma.glasnost.orika.test.common.types.TestCaseClasses.PrimitiveWrapperHolder;
 

--- a/tests/src/main/java/ma/glasnost/orika/test/converter/CloneableConverterNoSetAccessibleTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/converter/CloneableConverterNoSetAccessibleTestCase.java
@@ -31,9 +31,8 @@ import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.converter.builtin.CloneableConverter;
 import ma.glasnost.orika.test.MappingUtil;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/tests/src/main/java/ma/glasnost/orika/test/converter/CloneableConverterTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/converter/CloneableConverterTestCase.java
@@ -36,10 +36,9 @@ import ma.glasnost.orika.converter.builtin.PassThroughConverter;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
 import ma.glasnost.orika.test.MappingUtil;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.junit.Test;
-
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.junit.Assert;
 
 public class CloneableConverterTestCase {

--- a/tests/src/main/java/ma/glasnost/orika/test/converter/PassThroughConverterTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/converter/PassThroughConverterTestCase.java
@@ -24,8 +24,8 @@ import ma.glasnost.orika.metadata.Type;
 import ma.glasnost.orika.metadata.TypeBuilder;
 import ma.glasnost.orika.test.MappingUtil;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/tests/src/main/java/ma/glasnost/orika/test/extensibility/MappingContextFactoryExtensibilityTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/extensibility/MappingContextFactoryExtensibilityTestCase.java
@@ -8,8 +8,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/tests/src/main/java/ma/glasnost/orika/test/generator/ExpanderTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/generator/ExpanderTestCase.java
@@ -21,6 +21,10 @@ package ma.glasnost.orika.test.generator;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.junit.Assert;
 import ma.glasnost.orika.MapperFacade;
 import ma.glasnost.orika.MapperFactory;
@@ -30,10 +34,6 @@ import ma.glasnost.orika.metadata.ScoringClassMapBuilder;
 import ma.glasnost.orika.metadata.Type;
 import ma.glasnost.orika.metadata.TypeBuilder;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
 import org.junit.Test;
 
 /**

--- a/tests/src/main/java/ma/glasnost/orika/test/generator/TestCompilerStrategyWritingFiles.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/generator/TestCompilerStrategyWritingFiles.java
@@ -87,7 +87,8 @@ public class TestCompilerStrategyWritingFiles {
     	
     	} finally {
     		// Note: this is coming from hibernate jar which is included only for test
-    		IOUtils.deleteRecursive(generatedSrc.getParentFile().getAbsolutePath(), true);
+    		//TODO: is this still needed? The function doesn't exist anymore
+    		//IOUtils.deleteRecursive(generatedSrc.getParentFile().getAbsolutePath(), true);
     	}
     	
     }

--- a/tests/src/main/java/ma/glasnost/orika/test/generics/GenericCollectionsTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/generics/GenericCollectionsTestCase.java
@@ -30,8 +30,8 @@ import ma.glasnost.orika.metadata.ClassMapBuilder;
 import ma.glasnost.orika.metadata.Type;
 import ma.glasnost.orika.metadata.TypeBuilder;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/tests/src/main/java/ma/glasnost/orika/test/perf/MultiThreadedTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/perf/MultiThreadedTestCase.java
@@ -50,7 +50,7 @@ import ma.glasnost.orika.test.common.types.TestCaseClasses.Library;
 import ma.glasnost.orika.test.common.types.TestCaseClasses.LibraryDTO;
 import ma.glasnost.orika.test.common.types.TestCaseClasses.LibraryImpl;
 
-import org.apache.commons.lang.time.DateUtils;
+import org.apache.commons.lang3.time.DateUtils;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;

--- a/tests/src/main/java/ma/glasnost/orika/test/unenhance/HibernateProxyTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/unenhance/HibernateProxyTestCase.java
@@ -22,6 +22,8 @@ import ma.glasnost.orika.MapperFacade;
 import ma.glasnost.orika.test.MappingUtil;
 import ma.glasnost.orika.test.unenhance.SuperTypeTestCaseClasses.BookDTO;
 
+import java.io.Serializable;
+
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.junit.Assert;
@@ -44,7 +46,10 @@ public class HibernateProxyTestCase {
 	
 	@Autowired
 	private SessionFactory sessionFactory;
-	  
+	
+	private Serializable bookId;
+
+
 	
 	protected Session getSession() {
 	    return sessionFactory.getCurrentSession();
@@ -66,7 +71,7 @@ public class HibernateProxyTestCase {
 		book2.setTitle("The Prophet 2");
 		book.setAuthor(author);
 		
-		getSession().save(book);
+		bookId = getSession().save(book);
 		getSession().save(book2);
 		
 		/*
@@ -83,7 +88,7 @@ public class HibernateProxyTestCase {
 	@Test
 	public void testMappingProxyObject() {
 		
-		Book book = (Book) getSession().load(Book.class, 1L);
+		Book book = (Book) getSession().load(Book.class, bookId);
 		for (int i=0; i < 100; ++i) {
 			BookDTO bookDto = mapper.map(book, BookDTO.class);
 	

--- a/tests/src/main/resources/HibernateProxyTestCase-context.xml
+++ b/tests/src/main/resources/HibernateProxyTestCase-context.xml
@@ -28,7 +28,7 @@
     <property name="password" value=""/>
   </bean>
 
-  <bean id="sessionFactory" class="org.springframework.orm.hibernate3.annotation.AnnotationSessionFactoryBean">
+  <bean id="sessionFactory" class="org.springframework.orm.hibernate5.LocalSessionFactoryBean">
     <property name="dataSource" ref="dataSource"/>
     <property name="annotatedClasses">
       <list>
@@ -52,7 +52,7 @@
     </property>
   </bean>
 
-  <bean id="transactionManager" class="org.springframework.orm.hibernate3.HibernateTransactionManager">
+  <bean id="transactionManager" class="org.springframework.orm.hibernate5.HibernateTransactionManager">
     <property name="sessionFactory" ref="sessionFactory"/>
   </bean>
 </beans>

--- a/tests/src/main/resources/Issue20TestCase-context.xml
+++ b/tests/src/main/resources/Issue20TestCase-context.xml
@@ -28,7 +28,7 @@
     <property name="password" value=""/>
   </bean>
 
-  <bean id="sessionFactory" class="org.springframework.orm.hibernate3.annotation.AnnotationSessionFactoryBean">
+  <bean id="sessionFactory" class="org.springframework.orm.hibernate5.LocalSessionFactoryBean">
     <property name="dataSource" ref="dataSource"/>
     <property name="annotatedClasses">
       <list>
@@ -44,7 +44,7 @@
     </property>
   </bean>
 
-  <bean id="transactionManager" class="org.springframework.orm.hibernate3.HibernateTransactionManager">
+  <bean id="transactionManager" class="org.springframework.orm.hibernate5.HibernateTransactionManager">
     <property name="sessionFactory" ref="sessionFactory"/>
   </bean>
 </beans>

--- a/tests/src/main/resources/Issue21TestCase-context.xml
+++ b/tests/src/main/resources/Issue21TestCase-context.xml
@@ -28,7 +28,7 @@
     <property name="password" value=""/>
   </bean>
 
-  <bean id="sessionFactory" class="org.springframework.orm.hibernate3.annotation.AnnotationSessionFactoryBean">
+  <bean id="sessionFactory" class="org.springframework.orm.hibernate5.LocalSessionFactoryBean">
     <property name="dataSource" ref="dataSource"/>
     <property name="annotatedClasses">
       <list>
@@ -45,7 +45,7 @@
     </property>
   </bean>
 
-  <bean id="transactionManager" class="org.springframework.orm.hibernate3.HibernateTransactionManager">
+  <bean id="transactionManager" class="org.springframework.orm.hibernate5.HibernateTransactionManager">
     <property name="sessionFactory" ref="sessionFactory"/>
   </bean>
 </beans>


### PR DESCRIPTION
This is my attempt on updating some of the dependencies so orika is able to run on java 9.

After these changes orika can be build on java 7,8 and 9 😄 
see https://travis-ci.org/123Haynes/orika for confirmation.

@elaatifi can you please take a look when you have some time? 😃 

closes https://github.com/orika-mapper/orika/issues/141, https://github.com/orika-mapper/orika/issues/242