### PR TITLE
Remove Java 7 Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: java
 jdk:
-  - openjdk7
   - oraclejdk8
   - oraclejdk9
 branches:

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -107,7 +107,7 @@
 	          <version>1.16</version>
 	          <configuration>
 	          <jdk>
-            <version>[1.7.0)</version>
+            <version>[1.8.0)</version>
             <vendor>sun</vendor>
           </jdk>
 	          </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -300,8 +300,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.2</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 	    <plugin>
@@ -328,7 +328,7 @@
                 <configuration>
                     <sourceEncoding>utf-8</sourceEncoding>
                     <minimumTokens>100</minimumTokens>
-                    <targetJdk>1.7</targetJdk>
+                    <targetJdk>1.8</targetJdk>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Java 7 has reached its EOL since 2015.
Since keeping this old compability prevents orika
from using some newer libraries, let's remove support for it.  
No one in their right mind should use this old java version in actively maintained production environments where new versions of orika might be useful.