### PR TITLE
fix for https://github.com/orika-mapper/orika/issues/231 Same mapper …

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/metadata/ClassMapBuilder.java
+++ b/core/src/main/java/ma/glasnost/orika/metadata/ClassMapBuilder.java
@@ -271,7 +271,7 @@ public class ClassMapBuilder<A, B> implements MappedTypePair<A, B> {
      *            the (destination) fieldName from type A
      * @return
      */
-    public ClassMapBuilder<A, B> fieldBToA(String fieldNameB, String fieldNameA) {
+    public ClassMapBuilder<A, B> fieldBToA(String fieldNameA, String fieldNameB) {
         return fieldMap(fieldNameA, fieldNameB).bToA().add();
     }
     


### PR DESCRIPTION
Same mapper class is getting used for A to B and B to A mapping