### PR TITLE
more dependency updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: java
 jdk:
-  - openjdk7
   - oraclejdk8
   - oraclejdk9
 branches:

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -38,8 +38,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.googlecode.concurrentlinkedhashmap</groupId>
-			<artifactId>concurrentlinkedhashmap-lru</artifactId>
+		    <groupId>com.github.ben-manes.caffeine</groupId>
+		    <artifactId>caffeine</artifactId>
 		</dependency>
 
 		<dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -66,7 +66,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.0</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<phase>package</phase>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -107,7 +107,7 @@
 	          <version>1.16</version>
 	          <configuration>
 	          <jdk>
-            <version>[1.7.0)</version>
+            <version>[1.8.0)</version>
             <vendor>sun</vendor>
           </jdk>
 	          </configuration>

--- a/core/src/main/java/ma/glasnost/orika/converter/DefaultConverterFactory.java
+++ b/core/src/main/java/ma/glasnost/orika/converter/DefaultConverterFactory.java
@@ -45,7 +45,7 @@ import ma.glasnost.orika.util.HashMapUtility;
  */
 public class DefaultConverterFactory implements ConverterFactory, Reportable {
     
-    private static final Integer CACHE_SIZE = 2000;
+    private static final long CACHE_SIZE = 2000L;
     private final Map<ConverterKey, Converter<Object, Object>> converterCache;
     private Collection<Converter<Object, Object>> converters;
     private final Map<String, Converter<Object, Object>> convertersMap;
@@ -68,8 +68,8 @@ public class DefaultConverterFactory implements ConverterFactory, Reportable {
      * converters.
      */
     public DefaultConverterFactory() {
-        this(HashMapUtility.<ConverterKey, Converter<Object, Object>> getConcurrentLinkedHashMap(CACHE_SIZE),
-                new LinkedHashSet<Converter<Object, Object>>());
+    	this(HashMapUtility.<ConverterKey, Converter<Object, Object>> getCache(CACHE_SIZE).asMap(),
+        new LinkedHashSet<Converter<Object, Object>>());
     }
     
     public synchronized void setMapperFacade(MapperFacade mapperFacade) {

--- a/core/src/main/java/ma/glasnost/orika/impl/DefaultMapperFactory.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/DefaultMapperFactory.java
@@ -18,7 +18,7 @@
 
 package ma.glasnost.orika.impl;
 
-import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap;
+import com.github.benmanes.caffeine.cache.Cache;
 import ma.glasnost.orika.*;
 import ma.glasnost.orika.Properties;
 import ma.glasnost.orika.StateReporter.Reportable;
@@ -53,7 +53,7 @@ import static java.lang.System.getProperty;
 import static ma.glasnost.orika.OrikaSystemProperties.*;
 import static ma.glasnost.orika.StateReporter.DIVIDER;
 import static ma.glasnost.orika.StateReporter.humanReadableSizeInMemory;
-import static ma.glasnost.orika.util.HashMapUtility.getConcurrentLinkedHashMap;
+import static ma.glasnost.orika.util.HashMapUtility.getCache;
 
 /**
  * The mapper factory is the heart of Orika, a small container where metadata
@@ -71,7 +71,7 @@ public class DefaultMapperFactory implements MapperFactory, Reportable {
     protected final MapperGenerator mapperGenerator;
     protected final ObjectFactoryGenerator objectFactoryGenerator;
 
-    protected final ConcurrentLinkedHashMap<MapperKey, ClassMap<Object, Object>> classMapRegistry;
+    protected final Cache<MapperKey, ClassMap<Object, Object>> classMapRegistry;
     protected final SortedCollection<Mapper<Object, Object>> mappersRegistry;
     protected final SortedCollection<Filter<Object, Object>> filtersRegistry;
     protected final MappingContextFactory contextFactory;
@@ -109,7 +109,7 @@ public class DefaultMapperFactory implements MapperFactory, Reportable {
         
         this.converterFactory = new ConverterFactoryFacade(builder.converterFactory);
         this.compilerStrategy = builder.compilerStrategy;
-        this.classMapRegistry = getConcurrentLinkedHashMap(Integer.MAX_VALUE);
+        this.classMapRegistry = getCache(Long.valueOf(Integer.MAX_VALUE));
         this.mappersRegistry = new SortedCollection<Mapper<Object, Object>>(Ordering.MAPPER);
         this.filtersRegistry = new SortedCollection<Filter<Object, Object>>(Ordering.FILTER);
         this.explicitAToBRegistry = new ConcurrentHashMap<Type<?>, Set<Type<?>>>();
@@ -1281,7 +1281,7 @@ public class DefaultMapperFactory implements MapperFactory, Reportable {
                 }
                 converterFactory.setMapperFacade(mapperFacade);
                 
-                for (Map.Entry<MapperKey, ClassMap<Object, Object>> classMapEntry : classMapRegistry.entrySet()) {
+                for (Map.Entry<MapperKey, ClassMap<Object, Object>> classMapEntry : classMapRegistry.asMap().entrySet()) {
                     ClassMap<Object, Object> classMap = classMapEntry.getValue();
                     if (classMap.getUsedMappers().isEmpty()) {
                         classMapEntry.setValue(classMap.copyWithUsedMappers(discoverUsedMappers(classMap)));
@@ -1291,7 +1291,7 @@ public class DefaultMapperFactory implements MapperFactory, Reportable {
                 buildClassMapRegistry();
 
                 Map<ClassMap<?, ?>, GeneratedMapperBase> generatedMappers = new HashMap<ClassMap<?, ?>, GeneratedMapperBase>();
-                for (ClassMap<?, ?> classMap : classMapRegistry.values()) {
+                for (ClassMap<?, ?> classMap : classMapRegistry.asMap().values()) {
                     generatedMappers.put(classMap, buildMapper(classMap, false, context));
                 }
                 
@@ -1326,11 +1326,11 @@ public class DefaultMapperFactory implements MapperFactory, Reportable {
         // prepare a map for classmap (stored as set)
         Map<MapperKey, ClassMap<Object, Object>> classMapsDictionary = new HashMap<MapperKey, ClassMap<Object, Object>>();
         
-        for (final ClassMap<Object, Object> classMap : classMapRegistry.values()) {
+        for (final ClassMap<Object, Object> classMap : classMapRegistry.asMap().values()) {
             classMapsDictionary.put(new MapperKey(classMap.getAType(), classMap.getBType()), classMap);
         }
         
-        for (final ClassMap<?, ?> classMap : classMapRegistry.values()) {
+        for (final ClassMap<?, ?> classMap : classMapRegistry.asMap().values()) {
             MapperKey key = new MapperKey(classMap.getAType(), classMap.getBType());
             
             Set<ClassMap<Object, Object>> usedClassMapSet = new LinkedHashSet<ClassMap<Object, Object>>();
@@ -1369,7 +1369,7 @@ public class DefaultMapperFactory implements MapperFactory, Reportable {
          * should only add the most-specific of the available mappers to avoid
          * calling the same mapper multiple times during a single map request;
          */
-        for (ClassMap<?, ?> map : classMapRegistry.values()) {
+        for (ClassMap<?, ?> map : classMapRegistry.asMap().values()) {
             if (map.getAType().isAssignableFrom(classMapBuilder.getAType()) && map.getBType().isAssignableFrom(classMapBuilder.getBType())) {
                 if (!map.getAType().equals(classMapBuilder.getAType()) || !map.getBType().equals(classMapBuilder.getBType())) {
                     MapperKey key = new MapperKey(map.getAType(), map.getBType());
@@ -1515,7 +1515,7 @@ public class DefaultMapperFactory implements MapperFactory, Reportable {
     
     @SuppressWarnings("unchecked")
     public <A, B> ClassMap<A, B> getClassMap(MapperKey mapperKey) {
-        return (ClassMap<A, B>) classMapRegistry.get(mapperKey);
+        return (ClassMap<A, B>) classMapRegistry.getIfPresent(mapperKey);
     }
     
     public Set<Type<? extends Object>> lookupMappedClasses(Type<?> type) {

--- a/core/src/main/java/ma/glasnost/orika/util/HashMapUtility.java
+++ b/core/src/main/java/ma/glasnost/orika/util/HashMapUtility.java
@@ -18,13 +18,10 @@
 
 package ma.glasnost.orika.util;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 import ma.glasnost.orika.MappedTypePair;
-
-import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap;
-import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap.Builder;
 
 /**
  * HashMapUtility provides an wrapper for obtaining instances of ConcurrentLinkedHashMap
@@ -38,35 +35,13 @@ public class HashMapUtility {
      * @param capacity
      * @return a new instance of ConcurrentLinkedHashMap with the specified max weighted capacity
      */
-    public static <K, V extends MappedTypePair<Object, Object>> ConcurrentLinkedHashMap<K, V> getConcurrentLinkedHashMap(int capacity) {
+    public static <K, V extends MappedTypePair<Object, Object>> Cache<K, V> getCache(long capacity) {
         
-        Builder<K, V> builder = new ConcurrentLinkedHashMap.Builder<K, V>();
-       
-        /*
-         * Fix for maximumWeightedCapacity change from int to long between 1.2 version
-         * and newer 1.x versions; use reflection to detect int or long in the method
-         * signature
-         */
-        try {
-            Method maximumWeightedCapacity = ConcurrentLinkedHashMap.Builder.class.getMethod("maximumWeightedCapacity", int.class);
-            maximumWeightedCapacity.invoke(builder, capacity);
-        } catch (IllegalAccessException e) {
-            throw new IllegalStateException(e);
-        } catch (InvocationTargetException e) {
-            throw new IllegalStateException(e.getTargetException());
-        } catch (NoSuchMethodException e) {
-            try {
-                Method maximumWeightedCapacity = ConcurrentLinkedHashMap.Builder.class.getMethod("maximumWeightedCapacity", long.class);
-                maximumWeightedCapacity.invoke(builder, (long)capacity);
-            } catch (NoSuchMethodException e1) {
-                throw new IllegalStateException(e1);
-            } catch (IllegalAccessException e1) {
-                throw new IllegalStateException(e1);
-            } catch (InvocationTargetException e1) {
-                throw new IllegalStateException(e1);
-            }
-            
-        }
-        return builder.build();
+    	// Evict based on the number of entries in the cache
+    	return Caffeine.newBuilder()
+    	    .maximumSize(capacity)
+    	    .build();
+    	
+    	
     }
 }

--- a/eclipse-tools/pom.xml
+++ b/eclipse-tools/pom.xml
@@ -51,7 +51,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.0</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<phase>package</phase>

--- a/eclipse-tools/pom.xml
+++ b/eclipse-tools/pom.xml
@@ -31,17 +31,19 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 
-        <dependency>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>org.eclipse.jdt.core</artifactId>
-            <version>3.10.0.v20140604-1726</version>
-        </dependency>
-
 		<dependency>
-			<groupId>org.eclipse.text</groupId>
-			<artifactId>org.eclipse.text</artifactId>
-			<version>3.5.101</version>
+		    <groupId>org.eclipse.tycho</groupId>
+		    <artifactId>org.eclipse.jdt.core</artifactId>
+		    <version>3.14.0.v20171206-0802</version>
 		</dependency>
+		
+		
+		<dependency>
+		    <groupId>org.eclipse.platform</groupId>
+		    <artifactId>org.eclipse.text</artifactId>
+		    <version>3.6.100</version>
+		</dependency>
+
 
 
     </dependencies>

--- a/eclipse-tools/src/main/java/ma/glasnost/orika/impl/generator/EclipseJdtCompiler.java
+++ b/eclipse-tools/src/main/java/ma/glasnost/orika/impl/generator/EclipseJdtCompiler.java
@@ -96,10 +96,10 @@ public class EclipseJdtCompiler {
 	 * 
 	 * @return
 	 */
-	private Map<Object, Object> getFormattingOptions() {
+	private Map<String, String> getFormattingOptions() {
 
 		@SuppressWarnings("unchecked")
-		Map<Object, Object> options = DefaultCodeFormatterConstants
+		Map<String, String> options = DefaultCodeFormatterConstants
 				.getEclipseDefaultSettings();
 		options.put(JavaCore.COMPILER_SOURCE, JAVA_COMPILER_SOURCE_VERSION);
 		options.put(JavaCore.COMPILER_COMPLIANCE,
@@ -111,7 +111,7 @@ public class EclipseJdtCompiler {
 
 	private CompilerOptions getCompilerOptions() {
 
-		Map<Object, Object> options = new HashMap<Object, Object>();
+		Map<String, String> options = new HashMap<String, String>();
 
 		options.put(CompilerOptions.OPTION_LocalVariableAttribute,
 				CompilerOptions.GENERATE);

--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.7.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -345,7 +345,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.20.2</version>
+                <version>2.20</version>
                 <configuration>
                     <outputDirectory>${basedir}/target/surefire-reports</outputDirectory>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -202,41 +202,48 @@
             </dependency>
 
             <!-- Dependencies for optional eclipse jdt/formatter -->
-            <dependency>
-                <groupId>org.eclipse.core</groupId>
-                <artifactId>commands</artifactId>
-                <version>3.3.0-I20070605-0010</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse</groupId>
-                <artifactId>osgi</artifactId>
-                <version>3.3.0-v20070530</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.equinox</groupId>
-                <artifactId>common</artifactId>
-                <version>3.3.0-v20070426</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.core</groupId>
-                <artifactId>jobs</artifactId>
-                <version>3.3.0-v20070423</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.equinox</groupId>
-                <artifactId>registry</artifactId>
-                <version>3.3.0-v20070522</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.equinox</groupId>
-                <artifactId>preferences</artifactId>
-                <version>3.2.100-v20070522</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.core</groupId>
-                <artifactId>contenttype</artifactId>
-                <version>3.2.100-v20070319</version>
-            </dependency>
+			<dependency>
+			    <groupId>org.eclipse.platform</groupId>
+			    <artifactId>org.eclipse.core.commands</artifactId>
+			    <version>3.9.0</version>
+			</dependency>
+			
+			<dependency>
+			    <groupId>org.eclipse.platform</groupId>
+			    <artifactId>org.eclipse.osgi</artifactId>
+			    <version>3.12.50</version>
+			</dependency>
+			
+			<dependency>
+			    <groupId>org.eclipse.platform</groupId>
+			    <artifactId>org.eclipse.equinox.common</artifactId>
+			    <version>3.9.0</version>
+			</dependency>
+			
+			<dependency>
+			    <groupId>org.eclipse.platform</groupId>
+			    <artifactId>org.eclipse.core.jobs</artifactId>
+			    <version>3.9.2</version>
+			</dependency>
+			
+			<dependency>
+			    <groupId>org.eclipse.platform</groupId>
+			    <artifactId>org.eclipse.equinox.registry</artifactId>
+			    <version>3.7.0</version>
+			</dependency>
+			
+			<dependency>
+			    <groupId>org.eclipse.platform</groupId>
+			    <artifactId>org.eclipse.equinox.preferences</artifactId>
+			    <version>3.7.0</version>
+			</dependency>
+			
+			<dependency>
+			    <groupId>org.eclipse.platform</groupId>
+			    <artifactId>org.eclipse.core.contenttype</artifactId>
+			    <version>3.6.0</version>
+			</dependency>
+
             <!-- END Eclipse Test dependencies -->
 
             <dependency>
@@ -266,7 +273,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>18.0</version>
+                <version>24.0-jre</version>
             </dependency>
 
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -352,11 +352,6 @@
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
-                <artifactId>jdepend-maven-plugin</artifactId>
-                <version>2.0</version>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
                 <version>3.0.5</version>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -300,8 +300,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.2</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 	    <plugin>
@@ -328,7 +328,7 @@
                 <configuration>
                     <sourceEncoding>utf-8</sourceEncoding>
                     <minimumTokens>100</minimumTokens>
-                    <targetJdk>1.7</targetJdk>
+                    <targetJdk>1.8</targetJdk>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -173,12 +173,12 @@
                 <version>3.2.2</version>
                 <scope>test</scope>
             </dependency>
-
+            
             <dependency>
-                <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
-                <artifactId>concurrentlinkedhashmap-lru</artifactId>
-                <version>1.4.2</version>
-            </dependency>
+			    <groupId>com.github.ben-manes.caffeine</groupId>
+			    <artifactId>caffeine</artifactId>
+			    <version>2.6.1</version>
+			</dependency>
 
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -240,13 +240,6 @@
             <!-- END Eclipse Test dependencies -->
 
             <dependency>
-                <groupId>com.google.caliper</groupId>
-                <artifactId>caliper</artifactId>
-                <version>1.0-beta-2</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-library</artifactId>
                 <version>1.3</version>

--- a/tests-jdk8/pom.xml
+++ b/tests-jdk8/pom.xml
@@ -85,7 +85,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.3</version>
+				<version>3.7.0</version>
 				<configuration>
 					<source>${maven.compiler.source}</source>
 					<target>${maven.compiler.target}</target>
@@ -95,7 +95,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.18.1</version>
+				<version>2.20</version>
 				<configuration>
 					<argLine>-Xmx512m</argLine>
 					<systemPropertyVariables>

--- a/tests-jdk8/pom.xml
+++ b/tests-jdk8/pom.xml
@@ -10,7 +10,7 @@
 	<name>Orika - tests for JDK8</name>
 
 	<properties>
-		<javassist.version>3.20.0-GA</javassist.version>
+		<javassist.version>3.22.0-GA</javassist.version>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -159,7 +159,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.12.4</version>
+				<version>2.20</version>
 				<configuration>
           <argLine>-Xmx512m</argLine>
 					<testClassesDirectory>${project.build.outputDirectory}</testClassesDirectory>


### PR DESCRIPTION
Depends on https://github.com/orika-mapper/orika/pull/257

This PR assumes java 8 as the minimal Java Version.
It does the following:
* remove the old jdpend-maven plugin
  * developement of that has stopped and it doesn't seem to be used anywhere in the build process
* remove Caliper
  * this is an old Microbenchmark Framework that never made it out of beta. It also wasn't being used anywhere
* replace concurrentlinkedhashmap with [caffeine](https://github.com/ben-manes/caffeine)
  * it's the successor and it's supposed to be faster ( I did not measure this)
  * "Caffeine provides an in-memory cache using a Google Guava inspired API. The improvements draw on our experience designing Guava's cache and ConcurrentLinkedHashMap."
* update the eclipse dependencies
* update all maven plugins to their latest versions.
  * except for the surefire plugin, because the latest version breaks Java 9 compability
     (see https://issues.apache.org/jira/browse/SUREFIRE-1424)
* removes the commons-collections test dependency
  * development for this seems to have stopped in 2105
  * only `TreeList` was used from this in 3 tests. 

This PR has become quite big, so if it's hard to review, please let me know a I'll split it in smaller ones.