### PR TITLE
remove test dependency on commons-lang3 from the jdk8 tests

### DIFF
--- a/tests-jdk8/pom.xml
+++ b/tests-jdk8/pom.xml
@@ -66,12 +66,6 @@
 			<scope>compile</scope>
 		</dependency>
 
-		<dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-			<scope>compile</scope>
-		</dependency>
-
 	</dependencies>
 
 	<build>

--- a/tests-jdk8/src/test/java/ma/glasnost/orika/test/jdk8/JavaDateApiTest.java
+++ b/tests-jdk8/src/test/java/ma/glasnost/orika/test/jdk8/JavaDateApiTest.java
@@ -33,7 +33,6 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -192,7 +191,7 @@ public class JavaDateApiTest {
                 if (zipEntry.getName().startsWith(rootPackagePath)) {
                     String className = zipEntry.getName();
                     if (className.endsWith(".class")) {
-                        className = StringUtils.removeEnd(className, ".class");
+                        className = className.substring(0, className.length() - ".class".length());
                         className = className.replace('/', '.');
                         Class<?> clazz = Class.forName(className);
                         if (type.isAssignableFrom(clazz)) {
@@ -206,15 +205,15 @@ public class JavaDateApiTest {
         
         return subTypes;
     }
-    
+
     private File getJarFile(String filePath) throws Exception {
         String jarFilePath = filePath;
         jarFilePath = URLDecoder.decode(jarFilePath, "UTF-8");
         if (jarFilePath.startsWith("file:")) {
-            jarFilePath = StringUtils.substringAfter(jarFilePath, "file:");
+            jarFilePath = jarFilePath.substring(jarFilePath.lastIndexOf("file:") + "file:".length(), jarFilePath.length());
         }
         if (jarFilePath.contains(".jar!")) {
-            jarFilePath = StringUtils.substringBefore(jarFilePath, ".jar!") + ".jar";
+        	jarFilePath = jarFilePath.substring(0, jarFilePath.lastIndexOf(".jar!"))+ ".jar";
         }
         return new File(jarFilePath);
     }
@@ -358,5 +357,5 @@ public class JavaDateApiTest {
         }
 
     }
-    
+
 }


### PR DESCRIPTION
This is the first part to enable the complete removal of the old commons-lang3 dependency.