### PR TITLE
 bump version for javassist and easymock 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,11 +54,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <javassist.version>3.22.0-GA</javassist.version>
+        <javassist.version>3.23.1-GA</javassist.version>
         <springframework.version>4.3.14.RELEASE</springframework.version>
         <hibernate.version>5.0.12.Final</hibernate.version>
         <junit.version>4.12</junit.version>
-        <easymock.version>3.5.1</easymock.version>
+        <easymock.version>3.6</easymock.version>
         <h2.version>1.4.196</h2.version>
         <slf4j.version>1.7.25</slf4j.version>
         <paranamer.version>2.8</paranamer.version>

--- a/tests/src/main/java/ma/glasnost/orika/test/DynamicSuite.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/DynamicSuite.java
@@ -419,7 +419,7 @@ public class DynamicSuite extends ParentRunner<Runner> {
 								constructor
 										.setBody("{ super($1); this.scenarioName = $2; }");
 								subClass.addConstructor(constructor);
-								proxyClass = subClass.toClass();
+								proxyClass = (Class<? extends Runner>)subClass.toClass();
 
 							}
 						}


### PR DESCRIPTION
update javassist to 3.23.1-GA
update easymock to 3.6
add required cast needed for javassist update