### PR TITLE
Make sure java8 tests run on any jdk >= 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,7 +352,7 @@
         <profile>
             <id>include-jdk8-test</id>
             <activation>
-                <jdk>1.8</jdk>
+                <jdk>[1.8</jdk>
             </activation>
             <modules>
                 <module>tests-jdk8</module>

--- a/tests-jdk8/pom.xml
+++ b/tests-jdk8/pom.xml
@@ -10,7 +10,6 @@
 	<name>Orika - tests for JDK8</name>
 
 	<properties>
-		<javassist.version>3.22.0-GA</javassist.version>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
@@ -64,6 +63,12 @@
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
 			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.github.lukehutch</groupId>
+			<artifactId>fast-classpath-scanner</artifactId>
+			<version>3.1.9</version>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
- Make sure java8 tests run on any jdk >= 8
- Remove duplicated javassist.version property defined in orika-tests-jdk8 pom file
- Use fast-classpath-scanner library for finding subclasses - this library understands Java 9 modules