### PR TITLE
Add pluginManagement section to parent

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -61,7 +61,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -99,7 +98,6 @@
 	        <plugin>
 	          <groupId>org.codehaus.mojo</groupId>
 	          <artifactId>animal-sniffer-maven-plugin</artifactId>
-	          <version>1.16</version>
 	          <configuration>
 	          <jdk>
             <version>[1.8.0)</version>

--- a/eclipse-tools/pom.xml
+++ b/eclipse-tools/pom.xml
@@ -53,7 +53,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -274,11 +274,40 @@
     </repositories>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.0.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>3.2.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <version>1.17</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -287,7 +316,6 @@
 	    <plugin>
 	      <groupId>org.apache.maven.plugins</groupId>
 	      <artifactId>maven-javadoc-plugin</artifactId>
-	      <version>3.0.0</version>
 	      <configuration>
 		<additionalparam>-Xdoclint:none</additionalparam>
 	      </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.0</version>
+                    <version>2.22.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/tests-jdk8/pom.xml
+++ b/tests-jdk8/pom.xml
@@ -9,11 +9,6 @@
 	<artifactId>orika-tests-jdk8</artifactId>
 	<name>Orika - tests for JDK8</name>
 
-	<properties>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
-	</properties>
-
 	<dependencies>
 
 		<dependency>
@@ -77,18 +72,7 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.7.0</version>
-				<configuration>
-					<source>${maven.compiler.source}</source>
-					<target>${maven.compiler.target}</target>
-				</configuration>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.20</version>
 				<configuration>
 					<argLine>-Xmx512m</argLine>
 					<systemPropertyVariables>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -147,7 +147,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.20</version>
 				<configuration>
           <argLine>-Xmx512m</argLine>
 					<testClassesDirectory>${project.build.outputDirectory}</testClassesDirectory>


### PR DESCRIPTION
- Add pluginManagement section to control plugin versions
- Updated plugin versions
- Remove redundant maven-compiler-plugin entry in tests-jdk8. Java 8 source/target already setup in parent pom