### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,15 +54,15 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <javassist.version>3.24.0-GA</javassist.version>
-        <springframework.version>4.3.14.RELEASE</springframework.version>
-        <hibernate.version>5.0.12.Final</hibernate.version>
+        <javassist.version>3.24.1-GA</javassist.version>
+        <springframework.version>5.1.5.RELEASE</springframework.version>
+        <hibernate.version>5.4.1.Final</hibernate.version>
         <junit.version>4.12</junit.version>
-        <easymock.version>3.6</easymock.version>
-        <h2.version>1.4.196</h2.version>
-        <slf4j.version>1.7.25</slf4j.version>
+        <easymock.version>4.0.2</easymock.version>
+        <h2.version>1.4.197</h2.version>
+        <slf4j.version>1.7.26</slf4j.version>
         <paranamer.version>2.8</paranamer.version>
-        <logback.version>1.1.11</logback.version>
+        <logback.version>1.2.3</logback.version>
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
     </properties>
 
@@ -97,7 +97,7 @@
             <dependency>
                 <groupId>org.codehaus.janino</groupId>
                 <artifactId>janino</artifactId>
-                <version>3.0.8</version>
+                <version>3.0.12</version>
                 <scope>test</scope>
             </dependency>
 
@@ -134,23 +134,11 @@
                 <version>${hibernate.version}</version>
                 <scope>provided</scope>
             </dependency>
-            <dependency>
-                <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-entitymanager</artifactId>
-                <version>${hibernate.version}</version>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javassist</groupId>
-                        <artifactId>javassist</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
 
             <dependency>
                 <groupId>org.hibernate.common</groupId>
                 <artifactId>hibernate-commons-annotations</artifactId>
-                <version>5.0.1.Final</version>
+                <version>5.1.0.Final</version>
                 <scope>test</scope>
             </dependency>
 
@@ -186,63 +174,63 @@
 			<dependency>
 			    <groupId>org.eclipse.platform</groupId>
 			    <artifactId>org.eclipse.core.commands</artifactId>
-			    <version>3.9.0</version>
+			    <version>3.9.200</version>
 			</dependency>
 			
 			<dependency>
 			    <groupId>org.eclipse.platform</groupId>
 			    <artifactId>org.eclipse.osgi</artifactId>
-			    <version>3.12.50</version>
+			    <version>3.13.200</version>
 			</dependency>
 			
 			<dependency>
 			    <groupId>org.eclipse.platform</groupId>
 			    <artifactId>org.eclipse.equinox.common</artifactId>
-			    <version>3.9.0</version>
+			    <version>3.10.200</version>
 			</dependency>
 			
 			<dependency>
 			    <groupId>org.eclipse.platform</groupId>
 			    <artifactId>org.eclipse.core.jobs</artifactId>
-			    <version>3.9.2</version>
+			    <version>3.10.200</version>
 			</dependency>
 			
 			<dependency>
 			    <groupId>org.eclipse.platform</groupId>
 			    <artifactId>org.eclipse.equinox.registry</artifactId>
-			    <version>3.7.0</version>
+			    <version>3.8.200</version>
 			</dependency>
 			
 			<dependency>
 			    <groupId>org.eclipse.platform</groupId>
 			    <artifactId>org.eclipse.equinox.preferences</artifactId>
-			    <version>3.7.0</version>
+			    <version>3.7.200</version>
 			</dependency>
 			
 			<dependency>
 			    <groupId>org.eclipse.platform</groupId>
 			    <artifactId>org.eclipse.core.contenttype</artifactId>
-			    <version>3.6.0</version>
+			    <version>3.7.200</version>
 			</dependency>
 
             <!-- END Eclipse Test dependencies -->
 
             <dependency>
                 <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-library</artifactId>
-                <version>1.3</version>
+                <artifactId>hamcrest</artifactId>
+                <version>2.1</version>
             </dependency>
 
             <dependency>
                 <groupId>com.sun.xml.bind</groupId>
                 <artifactId>jaxb-impl</artifactId>
-                <version>2.3.0</version>
+                <version>2.3.2</version>
             </dependency>
 			
 			<dependency>
 				<groupId>javax.xml.bind</groupId>
 				<artifactId>jaxb-api</artifactId>
-				<version>2.3.0</version>
+				<version>2.3.1</version>
 			</dependency>
 			
             <dependency>
@@ -254,7 +242,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>24.0-jre</version>
+                <version>27.0.1-jre</version>
             </dependency>
 
         </dependencies>
@@ -279,7 +267,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -288,7 +276,7 @@
 	    <plugin>
 	      <groupId>org.apache.maven.plugins</groupId>
 	      <artifactId>maven-javadoc-plugin</artifactId>
-	      <version>2.9.1</version>
+	      <version>3.0.1</version>
 	      <configuration>
           <doclint>none</doclint>
           <additionalparam>-Xdoclint:none</additionalparam>
@@ -296,7 +284,6 @@
           <additionalJOption>-Xdoclint:none</additionalJOption>
 	      </configuration>
 	    </plugin>
-
         </plugins>
 
     </build>
@@ -308,7 +295,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.9.0</version>
+                <version>3.11.0</version>
                 <configuration>
                     <sourceEncoding>utf-8</sourceEncoding>
                     <minimumTokens>100</minimumTokens>
@@ -329,7 +316,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.20</version>
+                <version>2.22.1</version>
                 <configuration>
                     <outputDirectory>${basedir}/target/surefire-reports</outputDirectory>
                 </configuration>

--- a/tests-jdk8/pom.xml
+++ b/tests-jdk8/pom.xml
@@ -44,7 +44,7 @@
 
 		<dependency>
 			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
+			<artifactId>hamcrest</artifactId>
 		</dependency>
 
 		<dependency>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -50,7 +50,7 @@
 
 		<dependency>
 			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
+			<artifactId>hamcrest</artifactId>
 		</dependency>
 
 		<dependency>
@@ -73,7 +73,7 @@
 
 		<dependency>
 			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-entitymanager</artifactId>
+			<artifactId>hibernate-core</artifactId>
 			<scope>compile</scope>
 		</dependency>
 

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue160TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue160TestCase.java
@@ -1,7 +1,7 @@
 package ma.glasnost.orika.test.community;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 import org.junit.Test;
 

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue166TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue166TestCase.java
@@ -1,7 +1,7 @@
 package ma.glasnost.orika.test.community;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.CoreMatchers.is;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;

--- a/tests/src/main/java/ma/glasnost/orika/test/community/Issue167TestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/community/Issue167TestCase.java
@@ -1,9 +1,9 @@
 package ma.glasnost.orika.test.community;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
 import java.lang.reflect.Method;
 import java.util.HashSet;


### PR DESCRIPTION
This commit updates all dependencies to the latest
available stable version.
hibernate-entitymanager has been merged into hibernate-core
so I removed the old dependency.
Also hamcrest changed some classes around.

This should not affect functionality in any way. I just don't like having old libs with known security issues in the classpath :wink: