### PR TITLE
Merge changes from master

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Orika !
 -----------------------------------------------------------------------
 
-**NEW** We are pleased to announce the release of Orika **1.5.2** ! _This version is available on Maven central repository_ 
+**NEW** We are pleased to announce the release of Orika **1.5.4** ! _This version is available on Maven central repository_ 
 
 What?
 =====
@@ -37,3 +37,12 @@ How?
 Orika uses byte code generation to create fast mappers with minimal overhead. 
 
 Want to give Orika a try? Check out our new [User Guide](http://orika-mapper.github.com/orika-docs/) 
+
+Acknowledgements
+=================
+* YourKit supports Orika with its full-featured Java Profiler. Take a look at YourKit's leading software products: <a href="http://www.yourkit.com/java/profiler/index.jsp">YourKit Java Profiler</a>.
+<img src="https://www.yourkit.com/images/yklogo.png" title="YourKit">
+
+* <strong><a href="https://www.jetbrains.com/?from=Orika">JetBrains</a></strong> kindly provides Orika with a free open-source licence for their IntelliJ IDEA Ultimate edition. 
+<img src="https://camo.githubusercontent.com/a93f3a50613d2f7f26ca3cc70505e16921d6001b/687474703a2f2f7777772e6a6574627261696e732e636f6d2f696d672f6c6f676f732f6c6f676f5f696e74656c6c696a5f696465612e706e67">
+

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -47,10 +47,16 @@
 		</dependency>
 
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
 			<scope>test</scope>
 		</dependency>
+		
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
 
 		<dependency>
 			<groupId>org.hamcrest</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -54,7 +54,7 @@
 
 		<dependency>
 			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
+			<artifactId>hamcrest</artifactId>
 			<scope>test</scope>
 		</dependency>
 
@@ -78,7 +78,7 @@
 
 		<dependency>
 			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-entitymanager</artifactId>
+			<artifactId>hibernate-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/core/src/test/java/ma/glasnost/orika/test/community/Issue160TestCase.java
+++ b/core/src/test/java/ma/glasnost/orika/test/community/Issue160TestCase.java
@@ -18,15 +18,16 @@
 
 package ma.glasnost.orika.test.community;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import ma.glasnost.orika.BoundMapperFacade;
 import ma.glasnost.orika.CustomMapper;
 import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.MappingContext;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
-import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import org.junit.Test;
 
 /**
  * MapperFacade.map does not map into destination instance when context has already mapped the

--- a/core/src/test/java/ma/glasnost/orika/test/community/Issue166TestCase.java
+++ b/core/src/test/java/ma/glasnost/orika/test/community/Issue166TestCase.java
@@ -18,20 +18,21 @@
 
 package ma.glasnost.orika.test.community;
 
-import ma.glasnost.orika.MapperFacade;
-import ma.glasnost.orika.MapperFactory;
-import ma.glasnost.orika.impl.DefaultMapperFactory;
-import ma.glasnost.orika.metadata.Type;
-import ma.glasnost.orika.metadata.TypeFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import ma.glasnost.orika.MapperFacade;
+import ma.glasnost.orika.MapperFactory;
+import ma.glasnost.orika.impl.DefaultMapperFactory;
+import ma.glasnost.orika.metadata.Type;
+import ma.glasnost.orika.metadata.TypeFactory;
+
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * StackOverflowError exception when mapping enum.

--- a/core/src/test/java/ma/glasnost/orika/test/community/Issue167TestCase.java
+++ b/core/src/test/java/ma/glasnost/orika/test/community/Issue167TestCase.java
@@ -18,6 +18,15 @@
 
 package ma.glasnost.orika.test.community;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
 import ma.glasnost.orika.MapperFacade;
 import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
@@ -25,14 +34,8 @@ import ma.glasnost.orika.metadata.Type;
 import ma.glasnost.orika.metadata.TypeFactory;
 import ma.glasnost.orika.property.IntrospectorPropertyResolver;
 import ma.glasnost.orika.property.PropertyResolver;
+
 import org.junit.Test;
-
-import java.lang.reflect.Method;
-import java.util.HashSet;
-import java.util.Set;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 
 /**
  * DefaultMapperFactory.classMap got in infinity loop when using F-bounded polymorphism.

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <javassist.version>3.24.1-GA</javassist.version>
         <springframework.version>5.1.5.RELEASE</springframework.version>
         <hibernate.version>5.4.1.Final</hibernate.version>
-        <junit.version>4.12</junit.version>
+        <junit.version>5.4.0</junit.version>
         <easymock.version>4.0.2</easymock.version>
         <h2.version>1.4.197</h2.version>
         <slf4j.version>1.7.26</slf4j.version>
@@ -101,12 +101,24 @@
                 <scope>compile</scope>
             </dependency>
 
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.12</version>
-                <scope>test</scope>
-            </dependency>
+				    <dependency>
+				      <groupId>org.junit.jupiter</groupId>
+				      <artifactId>junit-jupiter-api</artifactId>
+				      <version>${junit.version}</version>
+				      <scope>test</scope>
+				    </dependency>
+				    <dependency>
+				      <groupId>org.junit.vintage</groupId>
+				      <artifactId>junit-vintage-engine</artifactId>
+				      <version>${junit.version}</version>
+				      <scope>test</scope>
+                <exclusions>
+                  <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                  </exclusion>
+                </exclusions>
+				    </dependency>
 
             <dependency>
                 <groupId>org.easymock</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,14 +73,14 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javassist.version>3.24.1-GA</javassist.version>
-        <springframework.version>4.3.14.RELEASE</springframework.version>
-        <hibernate.version>5.0.12.Final</hibernate.version>
+        <springframework.version>5.1.5.RELEASE</springframework.version>
+        <hibernate.version>5.4.1.Final</hibernate.version>
         <junit.version>4.12</junit.version>
-        <easymock.version>3.6</easymock.version>
-        <h2.version>1.4.196</h2.version>
-        <slf4j.version>1.7.25</slf4j.version>
+        <easymock.version>4.0.2</easymock.version>
+        <h2.version>1.4.197</h2.version>
+        <slf4j.version>1.7.26</slf4j.version>
         <paranamer.version>2.8</paranamer.version>
-        <logback.version>1.1.11</logback.version>
+        <logback.version>1.2.3</logback.version>
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
     </properties>
 
@@ -118,7 +118,7 @@
             <dependency>
                 <groupId>org.codehaus.janino</groupId>
                 <artifactId>janino</artifactId>
-                <version>3.0.8</version>
+                <version>3.0.12</version>
             </dependency>
 
             <dependency>
@@ -154,23 +154,11 @@
                 <version>${hibernate.version}</version>
                 <scope>test</scope>
             </dependency>
-            <dependency>
-                <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-entitymanager</artifactId>
-                <version>${hibernate.version}</version>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javassist</groupId>
-                        <artifactId>javassist</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
 
             <dependency>
                 <groupId>org.hibernate.common</groupId>
                 <artifactId>hibernate-commons-annotations</artifactId>
-                <version>5.0.1.Final</version>
+                <version>5.1.0.Final</version>
                 <scope>test</scope>
             </dependency>
 
@@ -197,22 +185,22 @@
 
             <dependency>
                 <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-library</artifactId>
-                <version>1.3</version>
+                <artifactId>hamcrest</artifactId>
+                <version>2.1</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>com.sun.xml.bind</groupId>
                 <artifactId>jaxb-impl</artifactId>
-                <version>2.3.0</version>
+                <version>2.3.2</version>
                 <scope>test</scope>
             </dependency>
 			
 			<dependency>
 				<groupId>javax.xml.bind</groupId>
 				<artifactId>jaxb-api</artifactId>
-				<version>2.3.0</version>
+				<version>2.3.1</version>
                 <scope>test</scope>
 			</dependency>
 
@@ -231,7 +219,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>11</source>
                     <target>11</target>
@@ -240,17 +228,15 @@
 	    <plugin>
 	      <groupId>org.apache.maven.plugins</groupId>
 	      <artifactId>maven-javadoc-plugin</artifactId>
-	      <version>2.9.1</version>
+	      <version>3.0.1</version>
 	      <configuration>
           <additionalparam>-Xdoclint:none</additionalparam>
           <additionalJOption>-Xdoclint:none</additionalJOption>
 	      </configuration>
 	    </plugin>
-
         </plugins>
 
     </build>
-
     <modules>
         <module>core</module>
     </modules>


### PR DESCRIPTION
This PR merges the changes from the master branch and fixes a few errors related to the hamcrest update.
Junit 4.12 still uses hamcrest 1.3, so I updated Junit to Junit 5 and excluded hamcrest there.

Please note that the Test for Issue 46 always fails locally for me. I'm not sure if this is because of my setup or if there really is an error.

the trace is:
```
java.lang.AssertionError: Failed to process graph. failed after 7 transforms, exception = ma.glasnost.orika.MappingException: While attempting the following mapping:
sourceClass = class ma.glasnost.orika.test.community.Issue46TestCase$Two
sourceType = ma.glasnost.orika.test.community.Issue46TestCase.Two
destinationType = ma.glasnost.orika.test.community.Issue46TestCase.Two
resolvedStrategy = InstantiateAndUseCustomMapperStrategy<Two, Two> {customMapper: GeneratedMapper<Two, Two> {usedConverters: [], usedMappers: [], usedMapperFacades: [], usedTypes: [] }, unenhancer: ma.glasnost.orika.unenhance.BaseUnenhancer@1800c1e3, objectFactory: ma.glasnost.orika.test.community.Two_Two_ObjectFactory731207897156700731208176335400$4@3b8b4846}
Error occurred: java.lang.ArrayIndexOutOfBoundsException: Index 10 out of bounds for length 3
	at ma.glasnost.orika.test.community.Issue46TestCase.test(Issue46TestCase.java:71)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at org.junit.vintage.engine.execution.RunnerExecutor.execute(RunnerExecutor.java:40)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
	at org.junit.vintage.engine.VintageTestEngine.executeAllChildren(VintageTestEngine.java:80)
	at org.junit.vintage.engine.VintageTestEngine.execute(VintageTestEngine.java:71)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:220)
	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$6(DefaultLauncher.java:188)
	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:202)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:181)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:128)
	at org.eclipse.jdt.internal.junit5.runner.JUnit5TestReference.run(JUnit5TestReference.java:89)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:41)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:541)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:763)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:463)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:209)


```