### PR TITLE
Remove unused dependencies

### DIFF
--- a/eclipse-tools/pom.xml
+++ b/eclipse-tools/pom.xml
@@ -42,6 +42,12 @@
 		    <groupId>org.eclipse.platform</groupId>
 		    <artifactId>org.eclipse.text</artifactId>
 		    <version>3.6.100</version>
+		    <exclusions>
+                        <exclusion>
+                            <groupId>org.eclipse.platform</groupId>
+                            <artifactId>org.eclipse.core.commands</artifactId>
+                        </exclusion>
+                    </exclusions>
 		</dependency>
 
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -123,11 +123,6 @@
 			<artifactId>spring-orm</artifactId>
 			<scope>compile</scope>
 		</dependency>
-
-		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
-			<artifactId>jaxb-impl</artifactId>
-		</dependency>
 		
 		<dependency>
 			<groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
Also, the transitive dependency `org.eclipse.core.commands` in module `orika-eclipse-tools` can be excluded, since it is not used.