### PR TITLE
Fix NPE if weak reference is GCd

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/metadata/TypeFactory.java
+++ b/core/src/main/java/ma/glasnost/orika/metadata/TypeFactory.java
@@ -441,7 +441,7 @@ public abstract class TypeFactory {
         if (mapped != null) {
             typeResult = (Type<T>) mapped.get();
         }
-        if (typeResult == null) {
+        if (mapped == null || typeResult == null) {
             synchronized (rawType) {
                 mapped = typeCache.get(key);
                 if (mapped != null) {


### PR DESCRIPTION
This PR fixes a NPE that happens if a WeakReference for Type is GC'd.