### PR TITLE
Reduce getter calls during fields mapping

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/impl/generator/MultiOccurrenceVariableRef.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/MultiOccurrenceVariableRef.java
@@ -67,6 +67,10 @@ public class MultiOccurrenceVariableRef extends VariableRef {
     }
     
     public String declareIterator() {
+        return declareIterator(getter());
+    }
+
+    public String declareIterator(String value) {
         if (iteratorDeclared) {
             throw new IllegalStateException("Iterator has already been declared");
         }
@@ -76,7 +80,7 @@ public class MultiOccurrenceVariableRef extends VariableRef {
         } else if (isMap()) {
             iterator = new EntrySetRef(this, name()).declareIterator();
         } else {
-            iterator = "java.util.Iterator " + getIteratorName() + " = " + getter() + ".iterator()";
+            iterator = "java.util.Iterator " + getIteratorName() + " = " + value + ".iterator()";
         }
         iteratorDeclared = true;
         return iterator;

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/Specification.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/Specification.java
@@ -31,11 +31,11 @@ import ma.glasnost.orika.metadata.FieldMap;
 public interface Specification extends BaseSpecification {
     
     void setMapperFactory(MapperFactory mapperFactory);
-    
+
     /**
      * Generates code for a boolean equality test between the two variable types,
      * where are potentially unrelated.
-     * 
+     *
      * @param source
      * @param destination
      * @param code
@@ -43,8 +43,7 @@ public interface Specification extends BaseSpecification {
      * whether the two types should be considered 'equal'
      */
     String generateEqualityTestCode(FieldMap fieldMap, VariableRef source, VariableRef destination, SourceCodeContext code);
-    
-    
+
     /**
      * Generates code to map the provided field map
      * 
@@ -55,5 +54,10 @@ public interface Specification extends BaseSpecification {
      * @return the code snippet which represents mapping from the source to destination
      * property
      */
-    String generateMappingCode(FieldMap fieldMap, VariableRef source, VariableRef destination, SourceCodeContext code);
+    default String generateMappingCode(FieldMap fieldMap, VariableRef source, VariableRef destination, SourceCodeContext code){
+        return generateMappingCode(fieldMap, source, source.toString(), destination, code);
+    }
+
+    String generateMappingCode(FieldMap fieldMap, VariableRef source, String sourceValue, VariableRef destination, SourceCodeContext code);
+
 }

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/specification/AbstractSpecification.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/specification/AbstractSpecification.java
@@ -74,7 +74,4 @@ public abstract class AbstractSpecification implements Specification {
     public String generateEqualityTestCode(FieldMap fieldMap, VariableRef source, VariableRef destination, SourceCodeContext code) {
         return format("%s.equals(%s)", source, destination);
     }
-    
-    public abstract String generateMappingCode(FieldMap fieldMap, VariableRef source, VariableRef destination, SourceCodeContext code);
-    
 }

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/specification/AnyTypeToString.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/specification/AnyTypeToString.java
@@ -37,24 +37,26 @@ public class AnyTypeToString extends AbstractSpecification {
         return "(\"\" + " + source + ").equals(" + destination +")";
     }
 
-    public String generateMappingCode(FieldMap fieldMap, VariableRef source, VariableRef destination, SourceCodeContext code) {
-        
+    @Override
+    public String generateMappingCode(FieldMap fieldMap, VariableRef source, String sourceValue, VariableRef destination, SourceCodeContext code) {
+
         if (source.isPrimitive()) {
             if (code.isDebugEnabled()) {
                 code.debugField(fieldMap, "converting primitive to String");
             }
-            
-            return statement(destination.assign("\"\"+ %s", source));
+
+            return statement(destination.assign("\"\"+ %s", sourceValue));
         } else {
             if (code.isDebugEnabled()) {
                 code.debugField(fieldMap, "converting " + source.typeName() + " using toString()");
             }
-            
+
             if (shouldMapNulls(fieldMap, code)) {
-                return statement("if (" + source.notNull() + ") {" + statement(destination.assign("%s.toString()", source)) + "} else {" + statement(destination.assign("null")) + "}");
+                return statement("if (" + source.notNull(sourceValue) + ") {" + statement(destination.assign("%s.toString()", sourceValue)) + "} else {" + statement(destination.assign("null")) + "}");
             } else {
-                return statement(source.ifNotNull() + destination.assign("%s.toString()", source));
+                return statement(source.ifNotNull(sourceValue) + destination.assign("%s.toString()", sourceValue));
             }
         }
+
     }
 }

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/specification/ApplyRegisteredMapper.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/specification/ApplyRegisteredMapper.java
@@ -34,9 +34,10 @@ public class ApplyRegisteredMapper extends ObjectToObject {
     public boolean appliesTo(FieldMap fieldMap) {
         return mapperFactory.existsRegisteredMapper(fieldMap.getAType(), fieldMap.getBType(), false);
     }
-    
-    public String generateMappingCode(FieldMap fieldMap, VariableRef source, VariableRef destination, SourceCodeContext code) {
-        
+
+    @Override
+    public String generateMappingCode(FieldMap fieldMap, VariableRef source, String sourceValue, VariableRef destination, SourceCodeContext code) {
+
         if (code.isDebugEnabled()) {
             Mapper<Object, Object> mapper = mapperFactory.lookupMapper(
                     new MapperKey(source.type(), destination.type()), code.getMappingContext());
@@ -52,7 +53,7 @@ public class ApplyRegisteredMapper extends ObjectToObject {
             code.debugField(fieldMap, "mapping using registered Mapper<" + sourceType + "," +
                     destType + ">");
         }
-        
-        return super.generateMappingCode(fieldMap, source, destination, code);
+
+        return super.generateMappingCode(fieldMap, source, sourceValue, destination, code);
     }
 }

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/specification/ArrayOrCollectionToArray.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/specification/ArrayOrCollectionToArray.java
@@ -34,27 +34,27 @@ public class ArrayOrCollectionToArray extends AbstractSpecification {
         return fieldMap.getDestination().isArray() && (fieldMap.getSource().isArray() || fieldMap.getSource().isCollection());
     }
 
+    @Override
+    public String generateMappingCode(FieldMap fieldMap, VariableRef source, String sourceValue, VariableRef destination, SourceCodeContext code) {
 
-    public String generateMappingCode(FieldMap fieldMap, VariableRef source, VariableRef destination, SourceCodeContext code) {
-        
         final VariableRef arrayVar = destination.elementRef(destination.name()+"Array__");
         String newArray = format("%s[] %s = new %s[%s]", destination.elementTypeName(), arrayVar.validVariableName(), destination.elementTypeName(), source.size());
-        
+
         String mapArray;
         if (destination.elementType().isPrimitive()) {
             if (code.isDebugEnabled()) {
                 code.debugField(fieldMap, "mapping to primitive array");
             }
-            mapArray = format("mapArray(%s, asList(%s), %s.class, mappingContext)", arrayVar.validVariableName(), source, arrayVar.typeName());
+            mapArray = format("mapArray(%s, asList(%s), %s.class, mappingContext)", arrayVar.validVariableName(), sourceValue, arrayVar.typeName());
         } else {
             if (code.isDebugEnabled()) {
                 code.debugField(fieldMap, "mapping to array");
             }
-            mapArray = format("mapperFacade.mapAsArray(%s, asList(%s), %s, %s, mappingContext)", arrayVar.validVariableName(), source, code.usedType(source.elementType()),
+            mapArray = format("mapperFacade.mapAsArray(%s, asList(%s), %s, %s, mappingContext)", arrayVar.validVariableName(), sourceValue, code.usedType(source.elementType()),
                     code.usedType(destination.elementType()));
         }
         String mapNull = shouldMapNulls(fieldMap, code) ? format(" else { %s; }", destination.assignIfPossible("null")) : "";
-        return format(" %s { %s; %s; %s; } %s", source.ifNotNull(), newArray, mapArray, destination.assign(arrayVar), mapNull);
+        return format(" %s { %s; %s; %s; } %s", source.ifNotNull(sourceValue), newArray, mapArray, destination.assign(arrayVar), mapNull);
     }
-    
+
 }

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/specification/ArrayOrCollectionToCollection.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/specification/ArrayOrCollectionToCollection.java
@@ -39,28 +39,29 @@ public class ArrayOrCollectionToCollection extends AbstractSpecification {
         return (fieldMap.getSource().isArray() || fieldMap.getSource().isCollection()) && fieldMap.getDestination().isCollection();
     }
 
-    public String generateMappingCode(FieldMap fieldMap, VariableRef source, VariableRef destination, SourceCodeContext code) {
-        
+    @Override
+    public String generateMappingCode(FieldMap fieldMap, VariableRef source, String sourceValue, VariableRef destination, SourceCodeContext code) {
+
         StringBuilder out = new StringBuilder();
-        
+
         MultiOccurrenceVariableRef s = MultiOccurrenceVariableRef.from(source);
         MultiOccurrenceVariableRef d = MultiOccurrenceVariableRef.from(destination);
-        
+
         final Class<?> destinationElementClass = d.elementType().getRawType();
-        
+
         if (destinationElementClass == null) {
-        	final String dc = destination.getOwner() == null ? "null" : destination.getOwner().rawType().getName();
+            final String dc = destination.getOwner() == null ? "null" : destination.getOwner().rawType().getName();
             throw new MappingException("cannot determine runtime type of destination collection " + dc + "." + d.name());
         }
-        
+
         // Start check if source property ! = null
-        out.append(s.ifNotNull() + " {\n");
-        
+        out.append(s.ifNotNull(sourceValue) + " {\n");
+
         /*
-         *  TODO: migrate this to create a new destination variable first; 
-         *  fill it, and then assign it to the destination using the setter. 
+         *  TODO: migrate this to create a new destination variable first;
+         *  fill it, and then assign it to the destination using the setter.
          */
-       
+
         MultiOccurrenceVariableRef newDest = new MultiOccurrenceVariableRef(d.type(), "new_" + d.validVariableName());
         if (d.isAssignable()) {
             out.append(statement(newDest.declare(d.newInstance(source.size()))));
@@ -68,18 +69,18 @@ public class ArrayOrCollectionToCollection extends AbstractSpecification {
             out.append(statement(newDest.declare(""+d)));
             out.append(statement("%s.clear()", newDest));
         }
-        
+
         if (s.isArray()) {
             if (code.isDebugEnabled()) {
                 code.debugField(fieldMap, "mapping " + s.elementTypeName() + "[] to Collection<" + d.elementTypeName() + ">");
             }
-            
+
             if (s.elementType().isPrimitive()) {
                 out.append("\n");
-                out.append(statement("%s.addAll(asList(%s));", newDest, s));
+                out.append(statement("%s.addAll(asList(%s));", newDest, sourceValue));
             } else {
                 out.append("\n");
-                out.append(statement("%s.addAll(mapperFacade.mapAsList(asList(%s), %s.class, mappingContext));", newDest, s, d.elementTypeName()));
+                out.append(statement("%s.addAll(mapperFacade.mapAsList(asList(%s), %s.class, mappingContext));", newDest, sourceValue, d.elementTypeName()));
             }
         } else {
             if (code.isDebugEnabled()) {
@@ -87,20 +88,20 @@ public class ArrayOrCollectionToCollection extends AbstractSpecification {
             }
             append(out,
                     "\n",
-                    format("%s.addAll(mapperFacade.mapAs%s(%s, %s, %s, mappingContext))", newDest, d.collectionType(), s,
+                    format("%s.addAll(mapperFacade.mapAs%s(%s, %s, %s, mappingContext))", newDest, d.collectionType(), sourceValue,
                             code.usedType(s.elementType()), code.usedType(d.elementType())));
         }
         if (fieldMap.getInverse() != null) {
             final MultiOccurrenceVariableRef inverse = new MultiOccurrenceVariableRef(fieldMap.getInverse(), "orikaCollectionItem");
-            
+
             if (fieldMap.getInverse().isCollection()) {
                 append(out,
-                          format("for (java.util.Iterator orikaIterator = %s.iterator(); orikaIterator.hasNext();) { ", newDest),
-                          format("    %s orikaCollectionItem = (%s) orikaIterator.next();", d.elementTypeName(), d.elementTypeName()),
-                          format("    %s { %s; }", inverse.ifNull(), inverse.assignIfPossible(inverse.newCollection())),
-                          format("    %s.add(%s)", inverse, d.owner()),
-                          "}");
-                
+                        format("for (java.util.Iterator orikaIterator = %s.iterator(); orikaIterator.hasNext();) { ", newDest),
+                        format("    %s orikaCollectionItem = (%s) orikaIterator.next();", d.elementTypeName(), d.elementTypeName()),
+                        format("    %s { %s; }", inverse.ifNull(), inverse.assignIfPossible(inverse.newCollection())),
+                        format("    %s.add(%s)", inverse, d.owner()),
+                        "}");
+
             } else if (fieldMap.getInverse().isArray()) {
                 out.append(" // TODO support array");
             } else {
@@ -109,20 +110,20 @@ public class ArrayOrCollectionToCollection extends AbstractSpecification {
                         format("    %s orikaCollectionItem = (%s) orikaIterator.next();", d.elementTypeName(), d.elementTypeName()),
                         inverse.assign(d.owner()),
                         "}");
-                
+
             }
         }
         // End check if source property ! = null
         if (d.isAssignable()) {
             out.append(statement(d.assign(newDest)));
         }
-        
+
         String assignNull = String.format("%s {\n%s;\n}", d.ifNotNull(), d.assignIfPossible("null"));
         String mapNull = shouldMapNulls(fieldMap, code) ? format(" else {\n %s;\n}", assignNull): "";
-        
+
         append(out, "}" + mapNull);
-        
+
         return out.toString();
     }
-    
+
 }

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/specification/CopyByReference.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/specification/CopyByReference.java
@@ -43,21 +43,22 @@ public class CopyByReference extends AbstractSpecification {
         
     }
 
-    public String generateMappingCode(FieldMap fieldMap, VariableRef source, VariableRef destination, SourceCodeContext code) {
-        
+    @Override
+    public String generateMappingCode(FieldMap fieldMap, VariableRef source, String sourceValue, VariableRef destination, SourceCodeContext code) {
+
         if (code.isDebugEnabled()) {
             code.debugField(fieldMap, "copying " + source.elementTypeName() + " by reference");
         }
-        
+
         StringBuilder out = new StringBuilder();
         if (!source.isPrimitive()) {
-            out.append(source.ifNotNull() + "{");
+            out.append(source.ifNotNull(sourceValue) + "{");
         }
         out.append(statement(destination.assign(source)));
         if (!source.isPrimitive()) {
             out.append("\n }");
             if (shouldMapNulls(fieldMap, code) && !destination.isPrimitive()) {
-                append(out, 
+                append(out,
                         " else {",
                         destination.assignIfPossible("null"),
                         "\n }");
@@ -65,5 +66,5 @@ public class CopyByReference extends AbstractSpecification {
         }
         return out.toString();
     }
-    
+
 }

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/specification/EnumToEnum.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/specification/EnumToEnum.java
@@ -36,16 +36,17 @@ public class EnumToEnum extends AbstractSpecification {
     public String generateEqualityTestCode(FieldMap fieldMap, VariableRef source, VariableRef destination, SourceCodeContext code) {
         return "(Enum.valueOf(%s.class, %s.name()) == " + destination + ")";
     }
-    
-    public String generateMappingCode(FieldMap fieldMap, VariableRef source, VariableRef destination, SourceCodeContext code) {
-        
+
+    @Override
+    public String generateMappingCode(FieldMap fieldMap, VariableRef source, String sourceValue, VariableRef destination, SourceCodeContext code) {
+
         if (code.isDebugEnabled()) {
             code.debugField(fieldMap, "converting enum " + source.typeName() + " to enum " + destination.typeName());
         }
-        
-        String assignEnum = destination.assign("Enum.valueOf(%s.class, %s.name())", destination.typeName(), source);
+
+        String assignEnum = destination.assign("Enum.valueOf(%s.class, %s.name())", destination.typeName(), sourceValue);
         String mapNull = shouldMapNulls(fieldMap, code) ? format(" else {\n %s;\n}", destination.assignIfPossible("null")): "";
-        return statement("%s { %s; } %s", source.ifNotNull(), assignEnum, mapNull);
+        return statement("%s { %s; } %s", source.ifNotNull(sourceValue), assignEnum, mapNull);
     }
 }
 

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/specification/MapToArray.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/specification/MapToArray.java
@@ -32,14 +32,16 @@ public class MapToArray extends ArrayOrCollectionToArray {
         return fieldMap.getSource().isMap() && fieldMap.getDestination().isArray();
     }
 
-    public String generateMappingCode(FieldMap fieldMap, VariableRef source, VariableRef destination, SourceCodeContext code) {
-        
+    @Override
+    public String generateMappingCode(FieldMap fieldMap, VariableRef source, String sourceValue, VariableRef destination, SourceCodeContext code) {
+
         if (code.isDebugEnabled()) {
-            code.debugField(fieldMap, "mapping Map<" + source.type().getNestedType(0) + ", " + 
+            code.debugField(fieldMap, "mapping Map<" + source.type().getNestedType(0) + ", " +
                     source.type().getNestedType(1) + "> to " + destination.elementTypeName() + "[]");
         }
-        
-        return super.generateMappingCode(fieldMap, entrySetRef(source), destination, code);
+
+        VariableRef entrySource = entrySetRef(source, sourceValue);
+
+        return super.generateMappingCode(fieldMap, entrySource, entrySource.toString(), destination, code);
     }
-    
 }

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/specification/MapToCollection.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/specification/MapToCollection.java
@@ -33,14 +33,16 @@ public class MapToCollection extends ArrayOrCollectionToCollection {
         return fieldMap.getSource().isMap() && fieldMap.getDestination().isCollection();
     }
 
-    public String generateMappingCode(FieldMap fieldMap, VariableRef source, VariableRef destination, SourceCodeContext code) {
-        
+    @Override
+    public String generateMappingCode(FieldMap fieldMap, VariableRef source, String sourceValue, VariableRef destination, SourceCodeContext code) {
+
         if (code.isDebugEnabled()) {
-            code.debugField(fieldMap, "mapping from Map<" + source.type().getNestedType(0) + ", " + 
+            code.debugField(fieldMap, "mapping from Map<" + source.type().getNestedType(0) + ", " +
                     source.type().getNestedType(1) + "> to Collection<" + destination.elementTypeName() + ">");
         }
-        
-        return super.generateMappingCode(fieldMap, entrySetRef(source), destination, code);
+
+        VariableRef entrySource = entrySetRef(source, sourceValue);
+
+        return super.generateMappingCode(fieldMap, entrySource, entrySource.toString(), destination, code);
     }
-    
 }

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/specification/MultiOccurrenceElementToObject.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/specification/MultiOccurrenceElementToObject.java
@@ -37,12 +37,13 @@ public class MultiOccurrenceElementToObject extends AbstractSpecification {
                 && (TypeFactory.TYPE_OF_OBJECT.equals(fieldMap.getSource().getType()));
     }
 
-    public String generateMappingCode(FieldMap fieldMap, VariableRef source, VariableRef destination, SourceCodeContext code) {
-        
+    @Override
+    public String generateMappingCode(FieldMap fieldMap, VariableRef source, String sourceValue, VariableRef destination, SourceCodeContext code) {
+
         if (code.isDebugEnabled()) {
             code.debugField(fieldMap, "mapping multi-occurrence element of type Object to object");
         }
-        
-        return statement(destination.assign(destination.cast(source)));
+
+        return statement(destination.assign(destination.cast(source, sourceValue)));
     }
 }

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/specification/MultiOccurrenceToMultiOccurrence.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/specification/MultiOccurrenceToMultiOccurrence.java
@@ -262,7 +262,9 @@ public class MultiOccurrenceToMultiOccurrence implements AggregateSpecification 
                     VariableRef d = makeVariable(currentNode.property, currentNode, "destination");
 
                     boolean getDestinationOnMapping = AbstractSpecification.shouldGetDestinationOnMapping(currentNode.getMap(), code);
-                    code.applyFilters(s, d, out, endWhiles, getDestinationOnMapping);
+                    code.addVariable(out, s);
+                    String destinationValue = code.optionallyMakeDestinationVariableAndGetValue(out, d, getDestinationOnMapping);
+                    code.applyFilters(s, d, out, endWhiles, s.getGlobalUniqueName(), destinationValue);
 
                     d = currentNode.isRoot() ? currentNode.newDestination : currentNode.multiOccurrenceVar;
                     out.append(format("\nmappingContext.beginMapping(%s, %s, %s, %s);\n",

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/specification/ObjectToMultiOccurrenceElement.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/specification/ObjectToMultiOccurrenceElement.java
@@ -39,21 +39,22 @@ public class ObjectToMultiOccurrenceElement extends AbstractSpecification {
         
     }
 
-    public String generateMappingCode(FieldMap fieldMap, VariableRef source, VariableRef destination, SourceCodeContext code) {
-        
+    @Override
+    public String generateMappingCode(FieldMap fieldMap, VariableRef source, String sourceValue, VariableRef destination, SourceCodeContext code) {
+
         if (code.isDebugEnabled()) {
             code.debugField(fieldMap, "mapping object to multi-occurrence element of type Object");
         }
-        
+
         StringBuilder out = new StringBuilder();
         if (!source.isPrimitive()) {
-            out.append(source.ifNotNull() + "{");
+            out.append(source.ifNotNull(sourceValue) + "{");
         }
-        out.append(statement(destination.assign(source)));
+        out.append(statement(destination.assign(source, sourceValue)));
         if (!source.isPrimitive()) {
             out.append("}");
             if (shouldMapNulls(fieldMap, code) && !destination.isPrimitive()) {
-                append(out, 
+                append(out,
                         " else {\n",
                         destination.assignIfPossible("null"),
                         "}\n");

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/specification/PrimitiveAndObject.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/specification/PrimitiveAndObject.java
@@ -45,19 +45,21 @@ public class PrimitiveAndObject extends AbstractSpecification {
         return source + " == " + destination;
     }
 
-    public String generateMappingCode(FieldMap fieldMap, VariableRef source, VariableRef destination, SourceCodeContext code) {
+    @Override
+    public String generateMappingCode(FieldMap fieldMap, VariableRef source, String sourceValue, VariableRef destination, SourceCodeContext code) {
+
         LOGGER.debug("PrimitiveAndObject condition occurred; context: " +
-                "\nsrc: " + source.property() + 
-                "\nsrc.isArrayElement: " + source.property().isArrayElement() + 
-                "\nsrc.isListElement: " + source.property().isListElement() + 
-                "\nsrc.isMapKey: " + source.property().isMapKey() + 
-                "\ndest: " + destination.property() + 
-                "\ndest.isArrayElement: " + destination.property().isArrayElement() + 
-                "\ndest.isListElement: " + destination.property().isListElement() + 
+                "\nsrc: " + source.property() +
+                "\nsrc.isArrayElement: " + source.property().isArrayElement() +
+                "\nsrc.isListElement: " + source.property().isListElement() +
+                "\nsrc.isMapKey: " + source.property().isMapKey() +
+                "\ndest: " + destination.property() +
+                "\ndest.isArrayElement: " + destination.property().isArrayElement() +
+                "\ndest.isListElement: " + destination.property().isListElement() +
                 "\ndest.isMapKey: " + destination.property().isMapKey()
-                );
+        );
         throw new MappingException("Encountered mapping of primitive to object (or vise-versa); sourceType="+
                 source.type() + ", destinationType=" + destination.type());
     }
-    
+
 }

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/specification/StringToEnum.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/specification/StringToEnum.java
@@ -39,14 +39,15 @@ public class StringToEnum extends AbstractSpecification {
         return "(Enum.valueOf(%s.class, \"\"+%s) == " + destination +")";
     }
 
-    public String generateMappingCode(FieldMap fieldMap, VariableRef source, VariableRef destination, SourceCodeContext code) {
-        
+    @Override
+    public String generateMappingCode(FieldMap fieldMap, VariableRef source, String sourceValue, VariableRef destination, SourceCodeContext code) {
+
         if (code.isDebugEnabled()) {
             code.debugField(fieldMap, "converting String to enum " + destination.type());
         }
-        
-        String assignEnum = destination.assign("Enum.valueOf(%s.class, \"\"+%s)", destination.typeName(), source);
+
+        String assignEnum = destination.assign("Enum.valueOf(%s.class, \"\"+%s)", destination.typeName(), sourceValue);
         String mapNull = shouldMapNulls(fieldMap, code) ? format(" else {\n %s;\n}", destination.assignIfPossible("null")): "";
-        return statement("%s { %s; } %s", source.ifNotNull(), assignEnum, mapNull);
+        return statement("%s { %s; } %s", source.ifNotNull(sourceValue), assignEnum, mapNull);
     }
 }

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/specification/StringToStringConvertible.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/specification/StringToStringConvertible.java
@@ -39,13 +39,14 @@ public class StringToStringConvertible extends AbstractSpecification {
         return "(" + source.notNull() + " && " + source + ".equals(\"\" + " + destination +"))";
     }
 
-    public String generateMappingCode(FieldMap fieldMap, VariableRef source, VariableRef destination, SourceCodeContext code) {
-        
+    @Override
+    public String generateMappingCode(FieldMap fieldMap, VariableRef source, String sourceValue, VariableRef destination, SourceCodeContext code) {
+
         if (code.isDebugEnabled()) {
             code.debugField(fieldMap, "converting from String to " + destination.type());
         }
-        
-        String value = source.toString();
+
+        String value = sourceValue;
         if (String.class.equals(source.rawType()) && (Character.class.equals(destination.rawType()) || char.class.equals(destination.rawType()))) {
             value = value + ".charAt(0)";
         }
@@ -53,7 +54,7 @@ public class StringToStringConvertible extends AbstractSpecification {
             return statement(destination.assign("%s.valueOf(%s)", destination.wrapperTypeName(), value));
         } else {
             String mapNull = shouldMapNulls(fieldMap, code) ? format(" else { %s; }", destination.assignIfPossible("null")): "";
-            return statement(format("%s {\n %s; } %s", source.ifNotNull(), destination.assign("%s.valueOf(%s)", destination.typeName(), value), mapNull));
+            return statement(format("%s {\n %s; } %s", source.ifNotNull(sourceValue), destination.assign("%s.valueOf(%s)", destination.typeName(), value), mapNull));
         }
     }
 }

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/specification/UnmappableEnum.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/specification/UnmappableEnum.java
@@ -36,9 +36,10 @@ public class UnmappableEnum extends AbstractSpecification {
         return fieldMap.getBType().isEnum() && !fieldMap.getAType().isEnum() && !fieldMap.getAType().isString();
     }
 
-    public String generateMappingCode(FieldMap fieldMap, VariableRef source, VariableRef destination, SourceCodeContext code) {
+    @Override
+    public String generateMappingCode(FieldMap fieldMap, VariableRef source, String sourceValue, VariableRef destination, SourceCodeContext code) {
         throw new MappingException("Encountered mapping of enum to object (or vise-versa); sourceType="+
                 source.type() + ", destinationType=" + destination.type());
     }
-    
+
 }

--- a/tests/src/main/java/ma/glasnost/orika/test/generator/CodeGenerationAddSpecificationCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/generator/CodeGenerationAddSpecificationCase.java
@@ -57,5 +57,11 @@ public class CodeGenerationAddSpecificationCase {
                                           SourceCodeContext code) {
             return super.generateMappingCode(fieldMap, source, destination, code);
         }
+
+        @Override
+        public String generateMappingCode(FieldMap fieldMap, VariableRef source, String sourceValue,
+                                          VariableRef destination, SourceCodeContext code) {
+            return super.generateMappingCode(fieldMap, source, sourceValue, destination, code);
+        }
     }
 }

--- a/tests/src/main/java/ma/glasnost/orika/test/generator/SingleGetterCallTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/generator/SingleGetterCallTestCase.java
@@ -1,0 +1,300 @@
+package ma.glasnost.orika.test.generator;
+
+import ma.glasnost.orika.MapperFactory;
+import ma.glasnost.orika.impl.DefaultMapperFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class SingleGetterCallTestCase {
+
+    public static class Container1 {
+        private long longValue1;
+        private String stringValue1;
+        private List<String> listOfString1;
+        private String[] arrayOfString1;
+        private int[] arrayOfInt1;
+        private Map<String, Object> map1;
+        private MapNullsTestCase.Position enumValue1;
+        private char charValue1;
+        private byte byteValue1;
+        private boolean booleanValue1;
+        private float floatValue1;
+        private double doubleValue1;
+
+        int longValue1GetterCalls, stringValue1GetterCalls, listOfString1GetterCalls,
+                arrayOfString1GetterCalls, arrayOfInt1GetterCalls, map1GetterCalls, enumValue1GetterCalls,
+                charValue1GetterCalls, byteValue1GetterCalls, booleanValue1GetterCalls, floatValue1GetterCalls,
+                doubleValue1GetterCalls;
+
+        public long getLongValue() {
+            ++longValue1GetterCalls;
+            return longValue1;
+        }
+
+        public void setLongValue(long longValue) {
+            this.longValue1 = longValue;
+        }
+
+        public String getStringValue() {
+            ++stringValue1GetterCalls;
+            return stringValue1;
+        }
+
+        public void setStringValue(String stringValue) {
+            this.stringValue1 = stringValue;
+        }
+
+        public List<String> getListOfString() {
+            ++listOfString1GetterCalls;
+            return listOfString1;
+        }
+
+        public void setListOfString(List<String> listOfString) {
+            this.listOfString1 = listOfString;
+        }
+
+        public String[] getArrayOfString() {
+            ++arrayOfString1GetterCalls;
+            return arrayOfString1;
+        }
+
+        public void setArrayOfString(String[] arrayOfString) {
+            this.arrayOfString1 = arrayOfString;
+        }
+
+        public int[] getArrayOfInt() {
+            ++arrayOfInt1GetterCalls;
+            return arrayOfInt1;
+        }
+
+        public void setArrayOfInt(int[] arrayOfInt) {
+            this.arrayOfInt1 = arrayOfInt;
+        }
+
+        public Map<String, Object> getMap() {
+            ++map1GetterCalls;
+            return map1;
+        }
+
+        public void setMap(Map<String, Object> map) {
+            this.map1 = map;
+        }
+
+        public MapNullsTestCase.Position getEnumValue() {
+            ++enumValue1GetterCalls;
+            return enumValue1;
+        }
+
+        public void setEnumValue(MapNullsTestCase.Position enumValue) {
+            this.enumValue1 = enumValue;
+        }
+
+        public char getCharValue1() {
+            ++charValue1GetterCalls;
+            return charValue1;
+        }
+
+        public void setCharValue1(char charValue1) {
+            this.charValue1 = charValue1;
+        }
+
+        public byte getByteValue1() {
+            ++byteValue1GetterCalls;
+            return byteValue1;
+        }
+
+        public void setByteValue1(byte byteValue1) {
+            this.byteValue1 = byteValue1;
+        }
+
+        public boolean isBooleanValue1() {
+            ++booleanValue1GetterCalls;
+            return booleanValue1;
+        }
+
+        public void setBooleanValue1(boolean booleanValue1) {
+            this.booleanValue1 = booleanValue1;
+        }
+
+        public float getFloatValue1() {
+            ++floatValue1GetterCalls;
+            return floatValue1;
+        }
+
+        public void setFloatValue1(float floatValue1) {
+            this.floatValue1 = floatValue1;
+        }
+
+        public double getDoubleValue1() {
+            ++doubleValue1GetterCalls;
+            return doubleValue1;
+        }
+
+        public void setDoubleValue1(double doubleValue1) {
+            this.doubleValue1 = doubleValue1;
+        }
+    }
+
+    public static class Container2 {
+        private long longValue1;
+        private String stringValue1;
+        private List<String> listOfString1;
+        private String[] arrayOfString1;
+        private int[] arrayOfInt1;
+        private Map<String, Object> map1;
+        private MapNullsTestCase.Position enumValue1;
+        private char charValue1;
+        private byte byteValue1;
+        private boolean booleanValue1;
+        private float floatValue1;
+        private double doubleValue1;
+
+        public long getLongValue() {
+            return longValue1;
+        }
+
+        public void setLongValue(long longValue) {
+            this.longValue1 = longValue;
+        }
+
+        public String getStringValue() {
+            return stringValue1;
+        }
+
+        public void setStringValue(String stringValue) {
+            this.stringValue1 = stringValue;
+        }
+
+        public List<String> getListOfString() {
+            return listOfString1;
+        }
+
+        public void setListOfString(List<String> listOfString) {
+            this.listOfString1 = listOfString;
+        }
+
+        public String[] getArrayOfString() {
+            return arrayOfString1;
+        }
+
+        public void setArrayOfString(String[] arrayOfString) {
+            this.arrayOfString1 = arrayOfString;
+        }
+
+        public int[] getArrayOfInt() {
+            return arrayOfInt1;
+        }
+
+        public void setArrayOfInt(int[] arrayOfInt) {
+            this.arrayOfInt1 = arrayOfInt;
+        }
+
+        public Map<String, Object> getMap() {
+            return map1;
+        }
+
+        public void setMap(Map<String, Object> map) {
+            this.map1 = map;
+        }
+
+        public MapNullsTestCase.Position getEnumValue() {
+            return enumValue1;
+        }
+
+        public void setEnumValue(MapNullsTestCase.Position enumValue) {
+            this.enumValue1 = enumValue;
+        }
+
+        public char getCharValue1() {
+            return charValue1;
+        }
+
+        public void setCharValue1(char charValue1) {
+            this.charValue1 = charValue1;
+        }
+
+        public byte getByteValue1() {
+            return byteValue1;
+        }
+
+        public void setByteValue1(byte byteValue1) {
+            this.byteValue1 = byteValue1;
+        }
+
+        public boolean isBooleanValue1() {
+            return booleanValue1;
+        }
+
+        public void setBooleanValue1(boolean booleanValue1) {
+            this.booleanValue1 = booleanValue1;
+        }
+
+        public float getFloatValue1() {
+            return floatValue1;
+        }
+
+        public void setFloatValue1(float floatValue1) {
+            this.floatValue1 = floatValue1;
+        }
+
+        public double getDoubleValue1() {
+            return doubleValue1;
+        }
+
+        public void setDoubleValue1(double doubleValue1) {
+            this.doubleValue1 = doubleValue1;
+        }
+    }
+
+    //FIXME: problem with primitive types. Somewhere it should be a wrapped type and somewhere it should as raw type but we are using a wrapped type everywhere
+    @Test
+    public void shouldMapWithSingleGetterCall(){
+
+        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().captureFieldContext(true).build();
+        mapperFactory.classMap(Container1.class, Container2.class)
+                .mapNulls(true)
+                .mapNullsInReverse(true)
+                .byDefault()
+                .register();
+
+        Container1 container1 = buildContainer1();
+        Container2 container2 = new Container2();
+
+        mapperFactory.getMapperFacade().map(container1, container2);
+
+        assertContainersEquals(container1, container2);
+
+        //TODO: check getter calls amount
+    }
+
+    private Container1 buildContainer1(){
+
+        Container1 container1 = new Container1();
+
+        container1.longValue1 = 1L;
+        container1.stringValue1 = "TEST A";
+        container1.arrayOfString1 = new String[]{"a", "b", "c"};
+        container1.arrayOfInt1 = new int[] {1,2,3};
+        container1.listOfString1 = Arrays.asList("l1","l2");
+        container1.map1 = Collections.singletonMap("key1", "value1");
+        container1.enumValue1 = MapNullsTestCase.Position.FIRST;
+
+        return container1;
+    }
+
+    private void assertContainersEquals(Container1 container1, Container2 container2){
+        Assert.assertEquals(container1.getLongValue(), container2.getLongValue());
+        Assert.assertEquals(container1.getStringValue(), container2.getStringValue());
+        Assert.assertEquals(container1.getListOfString(), container2.getListOfString());
+        Assert.assertArrayEquals(container1.getArrayOfInt(), container2.getArrayOfInt());
+        Assert.assertArrayEquals(container1.getArrayOfString(), container2.getArrayOfString());
+        Assert.assertEquals(container1.getMap(), container2.getMap());
+        Assert.assertEquals(container1.getEnumValue(), container2.getEnumValue());
+    }
+
+}


### PR DESCRIPTION
Partially resolves #346

This is proof of concept PR which shows that we can reduce unnecessary getter and setter calls by using variables.

This PR isn't complete and it doesn't handle primitive types. For some reason, I cannot create variables with primitive types and that is why I use primitive type wrappers (i.e. `Long` instead of `long`, `Integer` instead of `int`, etc.). 

Unfortunately, I couldn't correctly resolve problems with objects which has fields with primitive type.
I have included `SingleGetterCallTestCase` test case `shouldMapWithSingleGetterCall` which shows this problem. The PR correctly works with non primitive data types and you can see that the amount of getter calls is generally decreased about 2 times (often 1 call instead of 3 calls, 2-3 calls instead of 5 calls.) It is possible to decrease those calls more (possibly to 1 call) if we add variable values to `generateEqualityTestCode` inside `Specification` but for now I just extended implementation of `generateMappingCode`.

That said, it is just a proof of concept. I couldn't resolve the issue with primitive data types. If anyone knows what am I doing wrong or how to correctly handle primitive types, I would love to hear that and will try to resolve the issue. As I understand, we should use unwrapped primitive types somewhere and wrapped primitive types somewhere else but I am not sure where exactly. 

Also, if you someone wants to finish this optimization, feel free to take this PR and make any changes. I would really love to see this optimization to be implemented.

Stack trace:
```
javassist.CannotCompileException: [source error] setBooleanValue1(java.lang.Boolean) not found in ma.glasnost.orika.test.generator.SingleGetterCallTestCase$Container2
	at javassist.CtNewMethod.make(CtNewMethod.java:84)
	at javassist.CtNewMethod.make(CtNewMethod.java:50)
	at ma.glasnost.orika.impl.generator.JavassistCompilerStrategy.compileClass(JavassistCompilerStrategy.java:237)
	at ma.glasnost.orika.impl.generator.SourceCodeContext.compileClass(SourceCodeContext.java:246)
	at ma.glasnost.orika.impl.generator.SourceCodeContext.getInstance(SourceCodeContext.java:262)
	at ma.glasnost.orika.impl.generator.MapperGenerator.build(MapperGenerator.java:73)
	at ma.glasnost.orika.impl.DefaultMapperFactory.buildMapper(DefaultMapperFactory.java:1504)
	at ma.glasnost.orika.impl.DefaultMapperFactory.build(DefaultMapperFactory.java:1319)
	at ma.glasnost.orika.impl.DefaultMapperFactory.getMapperFacade(DefaultMapperFactory.java:907)
	at ma.glasnost.orika.test.generator.SingleGetterCallTestCase.shouldMapWithSingleGetterCall(SingleGetterCallTestCase.java:268)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:230)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:58)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.intellij.rt.execution.application.AppMainV2.main(AppMainV2.java:128)
Caused by: javassist.compiler.CompileError: setBooleanValue1(java.lang.Boolean) not found in ma.glasnost.orika.test.generator.SingleGetterCallTestCase$Container2
	at javassist.compiler.TypeChecker.atMethodCallCore(TypeChecker.java:777)
	at javassist.compiler.TypeChecker.atCallExpr(TypeChecker.java:723)
	at javassist.compiler.JvstTypeChecker.atCallExpr(JvstTypeChecker.java:170)
	at javassist.compiler.ast.CallExpr.accept(CallExpr.java:49)
	at javassist.compiler.CodeGen.doTypeCheck(CodeGen.java:266)
	at javassist.compiler.CodeGen.atStmnt(CodeGen.java:360)
	at javassist.compiler.ast.Stmnt.accept(Stmnt.java:53)
	at javassist.compiler.CodeGen.atStmnt(CodeGen.java:381)
	at javassist.compiler.ast.Stmnt.accept(Stmnt.java:53)
	at javassist.compiler.MemberCodeGen.atTryStmnt(MemberCodeGen.java:234)
	at javassist.compiler.CodeGen.atStmnt(CodeGen.java:397)
	at javassist.compiler.ast.Stmnt.accept(Stmnt.java:53)
	at javassist.compiler.CodeGen.atStmnt(CodeGen.java:381)
	at javassist.compiler.ast.Stmnt.accept(Stmnt.java:53)
	at javassist.compiler.CodeGen.atMethodBody(CodeGen.java:321)
	at javassist.compiler.CodeGen.atMethodDecl(CodeGen.java:303)
	at javassist.compiler.ast.MethodDecl.accept(MethodDecl.java:47)
	at javassist.compiler.Javac.compileMethod(Javac.java:175)
	at javassist.compiler.Javac.compile(Javac.java:102)
	at javassist.CtNewMethod.make(CtNewMethod.java:79)
	... 36 common frames omitted
20:33:03.534 [main] DEBUG m.g.o.impl.generator.MapperGenerator - Generating new mapper for (Container1, Container2)
	Orika_Container2_Container1_Mapper36939111491144$0.mapAToB(Container1, Container2) {
	 Field(arrayOfInt(int[]), arrayOfInt(int[])) : mapping to primitive array
	 Field(arrayOfString(String[]), arrayOfString(String[])) : mapping to array
	 Field(booleanValue1(boolean), booleanValue1(boolean)) : copying boolean by reference
	 Field(byteValue1(byte), byteValue1(byte)) : copying byte by reference
	 Field(charValue1(char), charValue1(char)) : copying char by reference
	 Field(doubleValue1(double), doubleValue1(double)) : copying double by reference
	 Field(enumValue(Position), enumValue(Position)) : copying Position by reference
	 Field(floatValue1(float), floatValue1(float)) : copying float by reference
	 Field(listOfString(List<String>), listOfString(List<String>)) : mapping Collection<java.lang.String> to Collection<java.lang.String>
	 Field(longValue(long), longValue(long)) : copying long by reference
	 Field(map(Map<String, Object>), map(Map<String, Object>)) : mapping from Map<String, Object> to Map<String, Object>
	 Field(key(String), key(String)) : copying String by reference
	 Field(value(Object), value(Object)) : mapping object to object
	 Field(stringValue(String), stringValue(String)) : copying String by reference
	}
	Orika_Container2_Container1_Mapper36939111491144$0.mapBToA(Container2, Container1) {
	 Field(arrayOfInt(int[]), arrayOfInt(int[])) : mapping to primitive array
	 Field(arrayOfString(String[]), arrayOfString(String[])) : mapping to array
	 Field(booleanValue1(boolean), booleanValue1(boolean)) : copying boolean by reference
	 Field(byteValue1(byte), byteValue1(byte)) : copying byte by reference
	 Field(charValue1(char), charValue1(char)) : copying char by reference
	 Field(doubleValue1(double), doubleValue1(double)) : copying double by reference
	 Field(enumValue(Position), enumValue(Position)) : copying Position by reference
	 Field(floatValue1(float), floatValue1(float)) : copying float by reference
	 Field(listOfString(List<String>), listOfString(List<String>)) : mapping Collection<java.lang.String> to Collection<java.lang.String>
	 Field(longValue(long), longValue(long)) : copying long by reference
	 Field(map(Map<String, Object>), map(Map<String, Object>)) : mapping from Map<String, Object> to Map<String, Object>
	 Field(key(String), key(String)) : copying String by reference
	 Field(value(Object), value(Object)) : mapping object to object
	 Field(stringValue(String), stringValue(String)) : copying String by reference
	}
<---- ERROR occurred here

ma.glasnost.orika.MappingException: ma.glasnost.orika.impl.generator.CompilerStrategy$SourceCodeGenerationException: Error compiling ma.glasnost.orika.generated.Orika_Container2_Container1_Mapper36939111491144$0

	at ma.glasnost.orika.impl.generator.MapperGenerator.build(MapperGenerator.java:104)
	at ma.glasnost.orika.impl.DefaultMapperFactory.buildMapper(DefaultMapperFactory.java:1504)
	at ma.glasnost.orika.impl.DefaultMapperFactory.build(DefaultMapperFactory.java:1319)
	at ma.glasnost.orika.impl.DefaultMapperFactory.getMapperFacade(DefaultMapperFactory.java:907)
	at ma.glasnost.orika.test.generator.SingleGetterCallTestCase.shouldMapWithSingleGetterCall(SingleGetterCallTestCase.java:268)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:230)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:58)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.intellij.rt.execution.application.AppMainV2.main(AppMainV2.java:128)
Caused by: ma.glasnost.orika.impl.generator.CompilerStrategy$SourceCodeGenerationException: Error compiling ma.glasnost.orika.generated.Orika_Container2_Container1_Mapper36939111491144$0
	at ma.glasnost.orika.impl.generator.JavassistCompilerStrategy.compileClass(JavassistCompilerStrategy.java:253)
	at ma.glasnost.orika.impl.generator.SourceCodeContext.compileClass(SourceCodeContext.java:246)
	at ma.glasnost.orika.impl.generator.SourceCodeContext.getInstance(SourceCodeContext.java:262)
	at ma.glasnost.orika.impl.generator.MapperGenerator.build(MapperGenerator.java:73)
	... 31 more
Caused by: javassist.CannotCompileException: [source error] setBooleanValue1(java.lang.Boolean) not found in ma.glasnost.orika.test.generator.SingleGetterCallTestCase$Container2
	at javassist.CtNewMethod.make(CtNewMethod.java:84)
	at javassist.CtNewMethod.make(CtNewMethod.java:50)
	at ma.glasnost.orika.impl.generator.JavassistCompilerStrategy.compileClass(JavassistCompilerStrategy.java:237)
	... 34 more
Caused by: compile error: setBooleanValue1(java.lang.Boolean) not found in ma.glasnost.orika.test.generator.SingleGetterCallTestCase$Container2
	at javassist.compiler.TypeChecker.atMethodCallCore(TypeChecker.java:777)
	at javassist.compiler.TypeChecker.atCallExpr(TypeChecker.java:723)
	at javassist.compiler.JvstTypeChecker.atCallExpr(JvstTypeChecker.java:170)
	at javassist.compiler.ast.CallExpr.accept(CallExpr.java:49)
	at javassist.compiler.CodeGen.doTypeCheck(CodeGen.java:266)
	at javassist.compiler.CodeGen.atStmnt(CodeGen.java:360)
	at javassist.compiler.ast.Stmnt.accept(Stmnt.java:53)
	at javassist.compiler.CodeGen.atStmnt(CodeGen.java:381)
	at javassist.compiler.ast.Stmnt.accept(Stmnt.java:53)
	at javassist.compiler.MemberCodeGen.atTryStmnt(MemberCodeGen.java:234)
	at javassist.compiler.CodeGen.atStmnt(CodeGen.java:397)
	at javassist.compiler.ast.Stmnt.accept(Stmnt.java:53)
	at javassist.compiler.CodeGen.atStmnt(CodeGen.java:381)
	at javassist.compiler.ast.Stmnt.accept(Stmnt.java:53)
	at javassist.compiler.CodeGen.atMethodBody(CodeGen.java:321)
	at javassist.compiler.CodeGen.atMethodDecl(CodeGen.java:303)
	at javassist.compiler.ast.MethodDecl.accept(MethodDecl.java:47)
	at javassist.compiler.Javac.compileMethod(Javac.java:175)
	at javassist.compiler.Javac.compile(Javac.java:102)
	at javassist.CtNewMethod.make(CtNewMethod.java:79)
	... 36 more
```