### PR TITLE
BoundStrategyCache race condition fix

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/impl/DefaultBoundMapperFacade.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/DefaultBoundMapperFacade.java
@@ -251,23 +251,20 @@ class DefaultBoundMapperFacade<A, B> implements BoundMapperFacade<A, B> {
         public MappingStrategy getStrategy(Object sourceObject, MappingContext context) {
             MappingStrategy strategy = null;
             Class<?> sourceClass = getClass(sourceObject);
-            if (defaultStrategy != null && sourceClass.equals(idClass)) {
-                strategy = defaultStrategy;
-            } else if (defaultStrategy == null) {
+            if (defaultStrategy == null) {
                 synchronized(this) {
                     if (defaultStrategy == null) {
                         defaultStrategy = mapperFacade.resolveMappingStrategy(sourceObject, aType, bType, inPlace, context);
                         idClass = sourceClass;
                         strategies.put(idClass, defaultStrategy);
                     }
-                }
+                } 
+            }
+            if (sourceClass.equals(idClass)) {
                 strategy = defaultStrategy;
             } else {
-                strategy = strategies.get(sourceClass);
-                if (strategy == null) {
-                    strategy = mapperFacade.resolveMappingStrategy(sourceObject, aType, bType, inPlace, context);
-                    strategies.put(sourceClass, strategy);
-                }
+                strategy = strategies.computeIfAbsent(sourceClass, 
+                        k -> mapperFacade.resolveMappingStrategy(sourceObject, aType, bType, inPlace, context));
             }
             
             /*

--- a/tests/src/main/java/ma/glasnost/orika/test/concurrency/DefaultBoundMapperFacadeConcurrentInitTestCase.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/concurrency/DefaultBoundMapperFacadeConcurrentInitTestCase.java
@@ -1,0 +1,89 @@
+package ma.glasnost.orika.test.concurrency;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import com.google.common.collect.Lists;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import ma.glasnost.orika.MapperFacade;
+import ma.glasnost.orika.MapperFactory;
+import ma.glasnost.orika.test.MappingUtil;
+import ma.glasnost.orika.test.concurrency.model.ModelWithNestedObjDest;
+import ma.glasnost.orika.test.concurrency.model.ModelWithNestedObjSource;
+import ma.glasnost.orika.test.concurrency.model.NestedModel;
+
+/**
+ * Checks that instantiation and cache inside of <{@link ma.glasnost.orika.impl.DefaultBoundMapperFacade} is thread safe.
+ */
+public class DefaultBoundMapperFacadeConcurrentInitTestCase {
+
+    private MapperFacade mapper;
+
+    private int threads = 20;
+    private ExecutorService executor;
+
+    @Before
+    public void setup() {
+        MapperFactory factory = MappingUtil.getMapperFactory();
+        factory.classMap(ModelWithNestedObjSource.class, ModelWithNestedObjDest.class)
+            .byDefault()
+            .register();
+
+        mapper = factory.getMapperFacade();
+
+        executor = Executors.newFixedThreadPool(threads);
+    }
+
+    @After
+    public void cleanup() {
+        if (executor != null) {
+            executor.shutdownNow();
+        } 
+    }
+
+    @Test
+    public void testCase() {
+        CountDownLatch readyLatch = new CountDownLatch(threads);
+
+        List<Future<?>> futures = IntStream.range(0, threads).mapToObj(i -> 
+            executor.submit(() -> {
+                ModelWithNestedObjSource model = i % 2 == 0 
+                    ? new ModelWithNestedObjSource(Lists.newArrayList(new NestedModel("str")))
+                    : new ModelWithNestedObjSource(Lists.newArrayList(new NestedModel(1)));
+                
+                readyLatch.countDown();
+                try {
+                    if (readyLatch.await(1, TimeUnit.SECONDS)) {
+                        Assert.assertEquals(model.getValue(), mapper.map(model, ModelWithNestedObjDest.class).getValue());
+                    } else {
+                        throw new RuntimeException("Latch timeout");
+                    }
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            })
+        ).collect(Collectors.toList());
+
+        // check that no exception thrown inside futures
+        for (Future<?> future : futures) {
+            try {
+                future.get(1, TimeUnit.SECONDS);
+            } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/tests/src/main/java/ma/glasnost/orika/test/concurrency/model/ModelWithNestedObjDest.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/concurrency/model/ModelWithNestedObjDest.java
@@ -1,0 +1,16 @@
+package ma.glasnost.orika.test.concurrency.model;
+
+import java.util.List;
+
+public class ModelWithNestedObjDest {
+
+    private List<NestedModel> value;
+
+    public List<NestedModel> getValue() {
+        return value;
+    }
+
+    public void setValue(List<NestedModel> value) {
+        this.value = value;
+    }
+}

--- a/tests/src/main/java/ma/glasnost/orika/test/concurrency/model/ModelWithNestedObjSource.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/concurrency/model/ModelWithNestedObjSource.java
@@ -1,0 +1,20 @@
+package ma.glasnost.orika.test.concurrency.model;
+
+import java.util.List;
+
+public class ModelWithNestedObjSource {
+
+    private List<NestedModel> value;
+
+    public ModelWithNestedObjSource(List<NestedModel> value) {
+        this.value = value;
+    }
+
+    public List<NestedModel> getValue() {
+        return value;
+    }
+
+    public void setValue(List<NestedModel> value) {
+        this.value = value;
+    }
+}

--- a/tests/src/main/java/ma/glasnost/orika/test/concurrency/model/NestedModel.java
+++ b/tests/src/main/java/ma/glasnost/orika/test/concurrency/model/NestedModel.java
@@ -1,0 +1,38 @@
+package ma.glasnost.orika.test.concurrency.model;
+
+import java.util.Objects;
+
+public class NestedModel {
+
+    private Object value;
+
+    public NestedModel(Object value) {
+        this.value = value;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public void setValue(Object value) {
+        this.value = value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        NestedModel other = (NestedModel) obj;
+        return Objects.equals(value, other.value);
+    }
+
+}


### PR DESCRIPTION
When several concurrent threads are trying to set `defaultStrategy` in `BoundStrategyCache` one of the threads may end up with wrong strategy. In that case the mapper will throw exception which will look something like this:

```
Caused by: ma.glasnost.orika.MappingException: While attempting the following mapping:
sourceClass = class ma.glasnost.orika.test.concurrency.model.NestedModel
sourceType = ma.glasnost.orika.test.concurrency.model.NestedModel
destinationType = ma.glasnost.orika.test.concurrency.model.NestedModel
resolvedStrategy = InstantiateAndUseCustomMapperStrategy<NestedModel, NestedModel> {customMapper: GeneratedMapper<NestedModel, NestedModel> {usedConverters: [], usedMappers: [], usedMapperFacades: [DefaultBoundMapperFacade<Object, Object>], usedTypes: [] }, unenhancer: ma.glasnost.orika.unenhance.BaseUnenhancer@101df177, objectFactory: ma.glasnost.orika.test.concurrency.model.NestedModel_NestedModel_ObjectFactory148371931701133148372477829116$2@166fa74d}
Error occurred: java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Integer
	at ma.glasnost.orika.impl.ExceptionUtility.newMappingException(ExceptionUtility.java:55)
	at ma.glasnost.orika.impl.MapperFacadeImpl.map(MapperFacadeImpl.java:264)
	at ma.glasnost.orika.impl.MapperFacadeImpl.mapElement(MapperFacadeImpl.java:799)
	at ma.glasnost.orika.impl.MapperFacadeImpl.mapAsCollection(MapperFacadeImpl.java:622)
	at ma.glasnost.orika.impl.MapperFacadeImpl.mapAsList(MapperFacadeImpl.java:428)
	at ma.glasnost.orika.generated.Orika_ModelWithNestedObjDest_ModelWithNestedObjSource_Mapper148372220603916$0.mapAtoB(Orika_ModelWithNestedObjDest_ModelWithNestedObjSource_Mapper148372220603916$0.java)
	at ma.glasnost.orika.impl.mapping.strategy.UseCustomMapperStrategy.map(UseCustomMapperStrategy.java:77)
	at ma.glasnost.orika.impl.MapperFacadeImpl.map(MapperFacadeImpl.java:672)
	at ma.glasnost.orika.impl.MapperFacadeImpl.map(MapperFacadeImpl.java:651)
	at ma.glasnost.orika.test.concurrency.DefaultBoundMapperFacadeConcurrentInitTestCase.lambda$1(DefaultBoundMapperFacadeConcurrentInitTestCase.java:70)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)

Caused by: java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Integer
	at ma.glasnost.orika.generated.Orika_Object_Integer_Mapper148372500018464$3.mapAtoB(Orika_Object_Integer_Mapper148372500018464$3.java)
	at ma.glasnost.orika.impl.mapping.strategy.UseCustomMapperStrategy.map(UseCustomMapperStrategy.java:77)
	at ma.glasnost.orika.impl.DefaultBoundMapperFacade.map(DefaultBoundMapperFacade.java:167)
	at ma.glasnost.orika.generated.Orika_NestedModel_NestedModel_Mapper148372460398666$1.mapAtoB(Orika_NestedModel_NestedModel_Mapper148372460398666$1.java)
	at ma.glasnost.orika.impl.mapping.strategy.UseCustomMapperStrategy.map(UseCustomMapperStrategy.java:77)
	at ma.glasnost.orika.impl.MapperFacadeImpl.map(MapperFacadeImpl.java:253)
	... 13 more
```