### PR TITLE
Use previously org.eclipse.platform.common version

### DIFF
--- a/eclipse-tools/pom.xml
+++ b/eclipse-tools/pom.xml
@@ -50,7 +50,11 @@
                     </exclusions>
 		</dependency>
 
-
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.equinox.common</artifactId>
+			<version>3.9.0</version>
+		</dependency>
 
     </dependencies>
 


### PR DESCRIPTION
Since version 3.15.0, org.eclipse.platform:org.eclipse.equinox.common  no longer compile on Java 8 libraries.