### PR TITLE
Update urls to docs in Readme.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://secure.travis-ci.org/orika-mapper/orika.png)](http://travis-ci.org/orika-mapper/orika)
 [![Join the chat at https://gitter.im/orika-mapper](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/orika-mapper/Lobby?utm_source=share-link&utm_medium=link&utm_campaign=share-link)
-[![GitHub site](https://img.shields.io/badge/GitHub-site-blue.svg)](http://orika-mapper.github.com/orika-docs/)
+[![GitHub site](https://img.shields.io/badge/GitHub-site-blue.svg)](http://orika-mapper.github.io/orika-docs/)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/ma.glasnost.orika/orika-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/ma.glasnost.orika/orika-core)
 [![Javadocs](http://www.javadoc.io/badge/ma.glasnost.orika/orika-core.svg)](http://www.javadoc.io/doc/ma.glasnost.orika/orika-core)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache_2.0-brightgreen.svg)](https://github.com/orika-mapper/orika/blob/master/LICENSE)
@@ -36,7 +36,7 @@ How?
 
 Orika uses byte code generation to create fast mappers with minimal overhead. 
 
-Want to give Orika a try? Check out our new [User Guide](http://orika-mapper.github.com/orika-docs/) 
+Want to give Orika a try? Check out our new [User Guide](http://orika-mapper.github.io/orika-docs/) 
 
 Acknowledgements
 =================


### PR DESCRIPTION
https://orika-mapper.github.com/orika-docs/ has changed to https://orika-mapper.github.io/orika-docs/