### PR TITLE
Remove java-sizeof as it's end of life

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,12 +190,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.carrotsearch</groupId>
-                <artifactId>java-sizeof</artifactId>
-                <version>0.0.5</version>
-            </dependency>
-
-            <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>27.0.1-jre</version>


### PR DESCRIPTION
Would you please consider to release a new version which have this PR include?