### PR TITLE
Fixed two non deterministic tests

### DIFF
--- a/core/src/test/java/ma/glasnost/orika/test/generator/BeanToArrayGenerationTestCase.java
+++ b/core/src/test/java/ma/glasnost/orika/test/generator/BeanToArrayGenerationTestCase.java
@@ -95,6 +95,8 @@ public class BeanToArrayGenerationTestCase {
                 .field("grade.percentage", "2")
                 .field("name.first", "3")
                 .field("name.last", "4")
+                .field("id", "5")
+                .field("email", "6")
                 .byDefault()
                 .register();
         

--- a/core/src/test/java/ma/glasnost/orika/test/metadata/ScoringClassMapBuilderTest.java
+++ b/core/src/test/java/ma/glasnost/orika/test/metadata/ScoringClassMapBuilderTest.java
@@ -79,11 +79,19 @@ public class ScoringClassMapBuilderTest {
     }
     
     @Test
-    public void testClassMapBuilderExtension() {
-        
+    public void testClassMapBuilderExtension() { 
+
         MapperFactory factory = new DefaultMapperFactory.Builder().classMapBuilderFactory(new ScoringClassMapBuilder.Factory()).build();
         
-        ClassMap<Source, Destination> map = factory.classMap(Source.class, Destination.class).byDefault().toClassMap();
+        ClassMap<Source, Destination> map = factory.classMap(Source.class, Destination.class)
+            .field("firstName", "name.first")
+            .field("lastName", "name.last")
+            .field("postalAddress.street", "streetAddress")
+            .field("postalAddress.country.alphaCode", "countryCode")
+            .field("age", "currentAge")
+            .field("stateOfBirth", "birthState")
+            .byDefault()
+            .toClassMap();
         Map<String, String> mapping = new HashMap<>();
         for (FieldMap f : map.getFieldsMapping()) {
             mapping.put(f.getSource().getExpression(), f.getDestination().getExpression());


### PR DESCRIPTION
### Fixed 2 non deterministic tests
- ma.glasnost.orika.test.generator.BeanToArrayGenerationTestCase.testBeanToStringArrayGeneration
- ma.glasnost.orika.test.metadata.ScoringClassMapBuilderTest.testClassMapBuilderExtension

### Steps to reproduce

To reproduce the problem, first build the module `core`:

> mvn install -pl core -am -DskipTests

To identify the flaky test, execute the following [nondex](https://github.com/TestingResearchIllinois/NonDex) command:

- For testBeanToStringArrayGeneration
> mvn -pl core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=ma.glasnost.orika.test.generator.BeanToArrayGenerationTestCase#testBeanToStringArrayGeneration

The test failure occurred due to random attribute ordering produced by factory.classMap(Clazz, Clazz). When field(fromClassField, toClassField) is not called for all hierarchical attributes, any attributes left unassigned will appear in a random order.
![image](https://github.com/user-attachments/assets/2e7c54e4-8805-48c4-a7aa-7fb0d017d227)


The fix involves adding lexographical ordering for all unmapped attributes ( email and id in this case ).

- For testClassMapBuilderExtension
> mvn -pl core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=ma.glasnost.orika.test.metadata.ScoringClassMapBuilderTest#testClassMapBuilderExtension

The test failure occurred because the fields are not being mapped correctly by default.
![image](https://github.com/user-attachments/assets/f600061e-0ccc-409d-89d7-371a97cb41f4)
![image](https://github.com/user-attachments/assets/f5a93ba2-a0f1-40a9-81b4-fb49442fb0b1)

The fix involves specifying explicit mappings for these fields.

<hr>

For more information : https://github.com/TestingResearchIllinois/NonDex
